### PR TITLE
Add logging options to facilitate json errors and general command-line use

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,19 +293,6 @@ E.g. if you wish to output your files in some other place than `output/`, you ca
 $ spago build --purs-args '-o myOutput/'
 ```
 
-It's possible to suppress or redirect Spago's logging in order to interact directly
-with `purs` output. The following examples use `jq` to format compilation errors
-rendered by `purs` as JSON. Specifically, the third example distinguishes between
-`purs` output and Spago output by configuring Spago to direct its own logging messages
-(but not those from `purs`) to file descriptor 3 for separate handling.
-
-```bash
-$ spago --quiet build --purs-args --json-errors 2> >( jq )
-$ spago --output-stream stdout build --purs-args --json-errors 2> >( jq )
-$ touch spago-log # Create a file for Spago's logging messages.
-$ spago -o 3 build -w -l -u --json-errors 3>> spago-log 4>&2 2>&1 1>&4 4>&- | jq
-```
-
 If you wish to automatically have your project rebuilt when making changes to source files
 you can use the `--watch` flag:
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,15 @@ E.g. if you wish to output your files in some other place than `output/`, you ca
 $ spago build --purs-args '-o myOutput/'
 ```
 
+It's possible to suppress or redirect Spago's logging in order to interact directly
+with `purs` output. The following two examples use `jq` to format compilation errors
+rendered by `purs` as JSON.
+
+```bash
+$ spago --quiet build --purs-args '--json-errors' 2> >( jq )
+$ spago --output-stream stdout build --purs-args '--json-errors' 2> >( jq )
+```
+
 If you wish to automatically have your project rebuilt when making changes to source files
 you can use the `--watch` flag:
 
@@ -1153,9 +1162,9 @@ that is accepted by many commands. You can either:
 
 ### Know the output path for my compiled code
 
-As there are now various factors that can affect the output path of compiled code, run 
-`spago path output` along with any flags you would pass to `spago build` (like 
-`--purs-args` or `--no-share-output`) to return the output path Spago is using. 
+As there are now various factors that can affect the output path of compiled code, run
+`spago path output` along with any flags you would pass to `spago build` (like
+`--purs-args` or `--no-share-output`) to return the output path Spago is using.
 This can be useful for sharing an output folder with `webpack`, for instance.
 
 ## Explanations

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ rendered by `purs` as JSON. Specifically, the third example distinguishes betwee
 $ spago --quiet build --purs-args --json-errors 2> >( jq )
 $ spago --output-stream stdout build --purs-args --json-errors 2> >( jq )
 $ touch spago-log # Create a file for Spago's logging messages.
-$ spago -O 3 build -w -l -u --json-errors 3>> spago-log 4>&2 2>&1 1>&4 4>&- | jq
+$ spago -o 3 build -w -l -u --json-errors 3>> spago-log 4>&2 2>&1 1>&4 4>&- | jq
 ```
 
 If you wish to automatically have your project rebuilt when making changes to source files

--- a/README.md
+++ b/README.md
@@ -294,12 +294,16 @@ $ spago build --purs-args '-o myOutput/'
 ```
 
 It's possible to suppress or redirect Spago's logging in order to interact directly
-with `purs` output. The following two examples use `jq` to format compilation errors
-rendered by `purs` as JSON.
+with `purs` output. The following examples use `jq` to format compilation errors
+rendered by `purs` as JSON. Specifically, the third example distinguishes between
+`purs` output and Spago output by configuring Spago to direct its own logging messages
+(but not those from `purs`) to file descriptor 3 for separate handling.
 
 ```bash
-$ spago --quiet build --purs-args '--json-errors' 2> >( jq )
-$ spago --output-stream stdout build --purs-args '--json-errors' 2> >( jq )
+$ spago --quiet build --purs-args --json-errors 2> >( jq )
+$ spago --output-stream stdout build --purs-args --json-errors 2> >( jq )
+$ touch spago-log # Create a file for Spago's logging messages.
+$ spago -O 3 build -w -l -u --json-errors 3>> spago-log 4>&2 2>&1 1>&4 4>&- | jq
 ```
 
 If you wish to automatically have your project rebuilt when making changes to source files

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -176,7 +176,7 @@ parser = do
             "2"      -> Just $ pure stderr
             "3"      -> Just handleForFD3
             _        -> Nothing
-      in CLI.optional $ CLI.opt wrap "output-stream" 'O' "Select the output stream for logging: any of `stdout`, `1`, `stderr`, `2`, or `3`."
+      in CLI.optional $ CLI.opt wrap "output-stream" 'o' "Select the output stream for logging: any of `stdout`, `1`, `stderr`, `2`, or `3`."
     versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     force       = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
@@ -220,8 +220,7 @@ parser = do
                     <*> beforeCommands <*> thenCommands <*> elseCommands
 
     -- Note: by default we limit concurrency to 20
-    globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> outputStream <*> usePsa
-                    <*> jobsLimit <*> configPath
+    globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> outputStream <*> usePsa <*> jobsLimit <*> configPath
 
 
     initProject =

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -395,9 +395,7 @@ runWithEnv GlobalOptions{..} app = do
         $ setLogVerboseFormat True logOptions'
   withLogFunc logOptions $ \logFunc -> do
     let logFunc' :: LogFunc
-        logFunc' = if globalQuiet
-          then mkLogFunc $ \_ _ _ _ -> pure ()
-          else logFunc
+        logFunc' = if globalQuiet then mempty else logFunc
 
     let configPath = fromMaybe Config.defaultPath globalConfigPath
 

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -4,14 +4,7 @@ import           Spago.Prelude
 
 import qualified Data.Text           as Text
 import           Data.Version        (showVersion)
-import           Foreign.C           (CInt (..))
-import qualified GHC.IO.Encoding     as Encoding
-import           GHC.IO.Exception    (IOException (..))
-import qualified GHC.IO.Exception    as IOErrorType (IOErrorType (..))
-import           GHC.IO.FD           (mkFD)
-import qualified GHC.IO.Handle       as Handle (BufferMode (..))
-import           GHC.IO.Handle.FD    (mkHandleFromFD)
-import qualified GHC.IO.Device       as Device (IODeviceType (..))
+import qualified GHC.IO.Encoding
 import qualified Options.Applicative as Opts
 import qualified Paths_spago         as Pcli
 import qualified System.Environment  as Env
@@ -36,6 +29,7 @@ import           Spago.Types
 import           Spago.Version       (VersionBump (..))
 import qualified Spago.Version
 import           Spago.Watch         (ClearScreen (..))
+
 
 -- | Commands that this program handles
 data Command
@@ -122,29 +116,12 @@ data GlobalOptions = GlobalOptions
   , globalVerbose     :: Bool
   , globalVeryVerbose :: Bool
   , globalUseColor    :: Bool
-  , globalLogHandle   :: Maybe (IO Handle)
   , globalUsePsa      :: UsePsa
   , globalJobs        :: Maybe Int
   , globalConfigPath  :: Maybe Text
   }
 
 data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
-
-handleForFD3 :: IO Handle
-handleForFD3 = do
-  (fd3, _) <- mkFD (Foreign.C.CInt 3) WriteMode Nothing False False `catch` manageFDException
-  handle' <- mkHandleFromFD fd3 Device.RegularFile "<nonstandard-stream>" WriteMode False (Just Encoding.utf8)
-  -- Handle 3's buffering is turned off. The handle is modeled after `stderr`,
-  -- which, in GHC.IO.Handle.FD, is also configured to be unbuffered.
-  hSetBuffering handle' Handle.NoBuffering
-  return handle'
-  where
-    manageFDException :: IOException -> IO a
-    manageFDException e@IOError{..} = case (ioe_type, ioe_location) of
-      (IOErrorType.UnsupportedOperation, "fdType") ->
-        throwIO $ SpagoError $ Messages.unopenLogHandle $ Text.pack $ show e
-      _ ->
-        throwIO e
 
 parser :: CLI.Parser (Command, GlobalOptions)
 parser = do
@@ -168,15 +145,6 @@ parser = do
     beforeCommands = many $ CLI.opt Just "before" 'b' "Commands to run before a build."
     thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successfull build."
     elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessfull build."
-    outputStream =
-      let wrap = \case
-            "stdout" -> Just $ pure stdout
-            "1"      -> Just $ pure stdout
-            "stderr" -> Just $ pure stderr
-            "2"      -> Just $ pure stderr
-            "3"      -> Just handleForFD3
-            _        -> Nothing
-      in CLI.optional $ CLI.opt wrap "output-stream" 'o' "Select the output stream for logging: any of `stdout`, `1`, `stderr`, `2`, or `3`."
     versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     force       = CLI.switch "force" 'f' "Overwrite any project found in the current directory"
@@ -220,7 +188,8 @@ parser = do
                     <*> beforeCommands <*> thenCommands <*> elseCommands
 
     -- Note: by default we limit concurrency to 20
-    globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> outputStream <*> usePsa <*> jobsLimit <*> configPath
+    globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> usePsa
+                    <*> jobsLimit <*> configPath
 
 
     initProject =
@@ -417,7 +386,7 @@ runWithEnv GlobalOptions{..} app = do
   let termDumb = maybeTerm == Just "dumb" || maybeTerm == Just "win"
   let useColor = globalUseColor && not termDumb
 
-  logHandle <- fromMaybe (pure stderr) globalLogHandle
+  let logHandle = stderr
   logOptions' <- logOptionsHandle logHandle verbose
   let logOptions
         = setLogUseTime globalVeryVerbose
@@ -448,7 +417,7 @@ runWithEnv GlobalOptions{..} app = do
 main :: IO ()
 main = do
   -- We always want to run in UTF8 anyways
-  Encoding.setLocaleEncoding Encoding.utf8
+  GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
   -- Stop `git` from asking for input, not gonna happen
   -- We just fail instead. Source:
   -- https://serverfault.com/questions/544156

--- a/package.yaml
+++ b/package.yaml
@@ -46,54 +46,105 @@ default-extensions:
 
 library:
   source-dirs: src
-  dependencies:
-  - aeson
-  - aeson-pretty
-  - ansi-terminal
-  - async-pool
-  - base >= 4.7 && < 5
-  - bower-json
-  - bytestring
-  - Cabal
-  - containers
-  - dhall >= 1.29.0
-  - directory >= 1.3.4.0
-  - either
-  - exceptions
-  - file-embed
-  - filepath
-  - foldl
-  - fsnotify
-  - github
-  - Glob
-  - http-client
-  - http-conduit
-  - lens-family-core
-  - megaparsec >=7.0 && <8.0
-  - mtl
-  - network-uri
-  - open-browser
-  - prettyprinter
-  - process
-  - retry
-  - rio
-  - rio-orphans
-  - safe
-  - semver-range
-  - stm
-  - tar
-  - template-haskell
-  - temporary
-  - text < 1.3
-  - time
-  - transformers
-  - turtle
-  - unix
-  - unliftio
-  - unordered-containers
-  - vector
-  - versions
-  - zlib
+  when:
+  - condition: os(windows)
+    then:
+      dependencies:
+      - aeson
+      - aeson-pretty
+      - ansi-terminal
+      - async-pool
+      - base >= 4.7 && < 5
+      - bower-json
+      - bytestring
+      - Cabal
+      - containers
+      - dhall
+      - directory >= 1.3.4.0
+      - either
+      - exceptions
+      - file-embed
+      - filepath
+      - foldl
+      - fsnotify
+      - github
+      - Glob
+      - http-client
+      - http-conduit
+      - lens-family-core
+      - megaparsec >=7.0 && <8.0
+      - mtl
+      - network-uri
+      - open-browser
+      - prettyprinter
+      - process
+      - retry
+      - rio
+      - rio-orphans
+      - safe
+      - semver-range
+      - stm
+      - tar
+      - template-haskell
+      - temporary
+      - text < 1.3
+      - time
+      - transformers
+      - turtle
+      - unliftio
+      - unordered-containers
+      - vector
+      - versions
+      - zlib
+    else:
+      dependencies:
+      - aeson
+      - aeson-pretty
+      - ansi-terminal
+      - async-pool
+      - base >= 4.7 && < 5
+      - bower-json
+      - bytestring
+      - Cabal
+      - containers
+      - dhall
+      - directory >= 1.3.4.0
+      - either
+      - exceptions
+      - file-embed
+      - filepath
+      - foldl
+      - fsnotify
+      - github
+      - Glob
+      - http-client
+      - http-conduit
+      - lens-family-core
+      - megaparsec >=7.0 && <8.0
+      - mtl
+      - network-uri
+      - open-browser
+      - prettyprinter
+      - process
+      - retry
+      - rio
+      - rio-orphans
+      - safe
+      - semver-range
+      - stm
+      - tar
+      - template-haskell
+      - temporary
+      - text < 1.3
+      - time
+      - transformers
+      - turtle
+      - unix
+      - unliftio
+      - unordered-containers
+      - vector
+      - versions
+      - zlib
 
 executables:
   spago:

--- a/package.yaml
+++ b/package.yaml
@@ -88,6 +88,7 @@ library:
   - time
   - transformers
   - turtle
+  - unix
   - unliftio
   - unordered-containers
   - vector

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -214,5 +214,14 @@ unopenLogHandle err = makeMessage
   , "One way of opening fd 3 in the UNIX shell bash is the following: `spago -o 3 build 3>&2`."
   ]
 
+noControllingTerminal :: Show a => a -> Text
+noControllingTerminal err = makeMessage
+  [ "WARNING: The file path for the controlling terminal could not be determined."
+  , "Details:"
+  , ""
+  , tshow err
+  , ""
+  ]
+
 makeMessage :: [Text] -> Text
 makeMessage = Text.intercalate "\n"

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -207,5 +207,12 @@ globsDoNotMatchWhenWatching :: NonEmpty Text -> Text
 globsDoNotMatchWhenWatching patterns = makeMessage $
   "WARNING: No matches found when trying to watch the following directories: " : NonEmpty.toList patterns
 
+unopenLogHandle :: Text -> Text
+unopenLogHandle err = makeMessage
+  [ tshow err
+  , "File descriptor 3 may not have been opened."
+  , "One way of opening fd 3 in the UNIX shell bash is the following: `spago -o 3 build 3>&2`."
+  ]
+
 makeMessage :: [Text] -> Text
 makeMessage = Text.intercalate "\n"

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -207,13 +207,6 @@ globsDoNotMatchWhenWatching :: NonEmpty Text -> Text
 globsDoNotMatchWhenWatching patterns = makeMessage $
   "WARNING: No matches found when trying to watch the following directories: " : NonEmpty.toList patterns
 
-unopenLogHandle :: Text -> Text
-unopenLogHandle err = makeMessage
-  [ tshow err
-  , "File descriptor 3 may not have been opened."
-  , "One way of opening fd 3 in the UNIX shell bash is the following: `spago -o 3 build 3>&2`."
-  ]
-
 noControllingTerminal :: Show a => a -> Text
 noControllingTerminal err = makeMessage
   [ "WARNING: The file path for the controlling terminal could not be determined."

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -7,7 +7,6 @@ module Spago.Prelude
   , Env (..)
   , UsePsa(..)
   , Spago
-  , SpagoError (..)
   , module X
   , Proxy(..)
   , NonEmpty (..)

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -7,6 +7,7 @@ module Spago.Prelude
   , Env (..)
   , UsePsa(..)
   , Spago
+  , SpagoError (..)
   , module X
   , Proxy(..)
   , NonEmpty (..)

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -4,7 +4,7 @@ module Spago.Watch (watch, globToParent, ClearScreen (..)) where
 -- This code basically comes straight from
 -- https://github.com/commercialhaskell/stack/blob/0740444175f41e6ea5ed236cd2c53681e4730003/src/Stack/FileWatch.hs
 
-import           Spago.Prelude          hiding (FilePath)
+import           Spago.Prelude          hiding (FilePath, hFlush)
 
 import           Control.Concurrent.STM (check)
 import qualified Data.Map.Strict        as Map
@@ -17,8 +17,8 @@ import           System.Console.ANSI    (clearScreen, setCursorPosition)
 import           System.FilePath        (splitDirectories)
 import qualified System.FilePath.Glob   as Glob
 import qualified System.FSNotify        as Watch
-import           System.IO              (getLine)
-import qualified UnliftIO
+import           System.IO              (getLine, hFlush, stdout)
+import qualified UnliftIO               hiding (hFlush)
 import           UnliftIO.Async         (race_)
 
 -- Should we clear the screen on rebuild?

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -103,7 +103,6 @@ fileWatchConf manager terminalHandle shouldClear globs action = do
         hClearScreen terminalHandle
         hSetCursorPosition terminalHandle 0 0
         when (terminalHandle == stdout) $ do
-          hPutStrLn terminalHandle "Flushing terminalHandle b/c stdout."
           hFlush terminalHandle
 
   let matches :: Watch.Event -> Glob.Pattern -> Bool
@@ -152,9 +151,9 @@ fileWatchConf manager terminalHandle shouldClear globs action = do
         when rebuilding $ do
           redisplayAndTryAction $ Just $ "File changed, triggered a build: " <> displayShow (Watch.eventPath event)
 
-  let watchGlobs :: Set.Set Glob.Pattern -> Spago ()
-      watchGlobs globs' = do
-        forM_ (Set.toList globs') $ \glob -> liftIO $
+  let watchGlobs :: Spago ()
+      watchGlobs = do
+        forM_ (Set.toList globs) $ \glob -> liftIO $
           Watch.watchTree manager (globToParent glob) (const True) (runRIO env . onChange)
 
   let watchInput :: Spago ()
@@ -182,7 +181,7 @@ fileWatchConf manager terminalHandle shouldClear globs action = do
 
   spawnRunActionThread
   tryAction
-  watchGlobs globs
+  watchGlobs
   watchInput
 
 globToParent :: Glob.Pattern -> FilePath


### PR DESCRIPTION
### Description of the change

Spago has a lot of functionality. One of its primary responsibilities, though, is to make using the `purs` executable easier -- that is, Spago calls `purs` directly, provides some output guidance, and interleaves logging metadata but otherwise stays out of the compiler's way. Because end users employ Spago during development to interact with `purs`, there have been a few issues (e.g., #154, #170, #256, #316) asking for greater separation between Spago logging and `purs` output. PR #475 does a good job of this by having Spago log to __stderr__. However, as @hdgarrood mentions in #256, this approach doesn't fully isolate Spago metadata from `purs` data, since the compiler prints json errors to the same __stderr__ stream. For common Spago use cases, this mingling of streams isn't much of a problem in itself, but it does make pipelining on the command-line difficult, since Spago's logging messages then affect downstream processing. This pull request offers a possible remedy by giving users greater control over Spago logging, including the option of dedicating a file handle exclusively to Spago output and the option of suppressing logging entirely.

Here's an example of the former CLI option. In the bash command below, logging by `purs` on __stdout__ is suppressed and logging by Spago on Spago's own file handle 3 is redirected to __stderr__. Because compilation errors, originally on __stderr__, are redirected to __stdout__, they can be piped for additional processing.

``` bash
$ spago --output-stream 3 build -n -u --json-errors 3>&2 2>&1 1>/dev/null | ./format.sh

{
  "warnings": [
    {
      "warningCode": "UnusedImport",
      "loc": "start: 4, end: 4, file: src/Main.purs",
      "msg": " The import of Data.Either is redundant "
    }
  ],
  "errors": [
    {
      "errorCode": "TypesDoNotUnify",
      "loc": "start: 10, end: 10, file: src/Main.purs",
      "msg": " Could not match type Effect with type Function Int while trying to match type Effect Unit with type Int -> t0 while checking that expression (log \"\\127837\") 3 has type Effect Unit in value declaration main where t0 is an unknown type "
    }
  ]
}
[error] Failed to build.
```

_src/Main.purs_
``` purescript
module Main where

import Prelude (Unit)
import Data.Either
import Effect (Effect)
import Effect.Console (log)

main :: Effect Unit
main = do
  log "🍝" 3
```

_format.sh_
``` bash
#!/bin/sh
sed --unbuffered 's/\\n/ /g; s/\s\+/ /g' \
  | jq --unbuffered \
  ' { warnings:
        .warnings
        | [.[]
            | { warningCode: .errorCode
              , loc: "start: \(.position.startLine), end: \(.position.endLine), file: \(.filename)"
              , msg: .message
              }
          ]
    , errors:
        .errors
        | [.[]
            | { errorCode: .errorCode
              , loc: "start: \(.position.startLine), end: \(.position.endLine), file: \(.filename)"
              , msg: .message
              }
          ]
    }
  '
```
-----
For comparison, and to show the usefulness of Spago pipelining, here's the same compilation output but without --json-errors and without formatting.

``` bash
$ spago --output-stream 3 build -n -u --json-errors 3>&2 2>&1 1>/dev/null

{"warnings":[{"position":{"startLine":4,"startColumn":1,"endLine":4,"endColumn":19},"message":"  The import of Data.Either is redundant\n","errorCode":"UnusedImport","errorLink":"https://github.com/purescript/documentation/blob/master/errors/UnusedImport.md","filename":"src/Main.purs","moduleName":"Main","suggestion":{"replacement":"","replaceRange":{"startLine":4,"startColumn":1,"endLine":4,"endColumn":19}},"allSpans":[{"start":[4,1],"name":"src/Main.purs","end":[4,19]}]}],"errors":[{"position":{"startLine":10,"startColumn":3,"endLine":10,"endColumn":12},"message":"  Could not match type\n\n    Effect\n\n  with type\n\n    Function Int\n\n\nwhile trying to match type Effect Unit\n  with type Int -> t0\nwhile checking that expression (log \"\\127837\") 3\n  has type Effect Unit\nin value declaration main\n\nwhere t0 is an unknown type\n","errorCode":"TypesDoNotUnify","errorLink":"https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md","filename":"src/Main.purs","moduleName":"Main","suggestion":null,"allSpans":[{"start":[10,3],"name":"src/Main.purs","end":[10,12]}]}]}
[error] Failed to build.
```

``` bash
$ spago -o 3 build -n 3>&2 1>/dev/null

Warning found:
in module Main
at src/Main.purs:4:1 - 4:19 (line 4, column 1 - line 4, column 19)

  The import of Data.Either is redundant


See https://github.com/purescript/documentation/blob/master/errors/UnusedImport.md for more information,
or to contribute content related to this warning.


Error found:
in module Main
at src/Main.purs:10:3 - 10:12 (line 10, column 3 - line 10, column 12)

  Could not match type

    Effect

  with type

    Function Int


while trying to match type Effect Unit
  with type Int -> t0
while checking that expression (log "\127837") 3
  has type Effect Unit
in value declaration main

where t0 is an unknown type

See https://github.com/purescript/documentation/blob/master/errors/TypesDoNotUnify.md for more information,
or to contribute content related to this error.


[error] Failed to build.
```

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [X] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊