### PR TITLE
Make the "dropping the 'purescript-' prefix" warning milder

### DIFF
--- a/src/Spago/Packages.hs
+++ b/src/Spago/Packages.hs
@@ -220,11 +220,9 @@ reportMissingPackages (PackagesLookupResult found foundWithoutPrefix notFound) =
       [ "The following packages do not exist in your package set:" ]
       <> (fmap (\(NotFoundError (PackageName packageName)) -> display $ "  - " <> packageName) $ List.sort notFound)
 
-  for_ foundWithoutPrefix $ \(FoundWithoutPrefix sansPrefix) ->
-    logWarn
-    $ display
-    $ "The package 'purescript-" <> packageName sansPrefix <> "' was not found in your package set, but '"
-    <> packageName sansPrefix <> "' was. Using that instead."
+  for_ foundWithoutPrefix $ \(FoundWithoutPrefix (PackageName sansPrefix)) ->
+    logInfo $ display
+      $ "The package 'purescript-" <> sansPrefix <> "' was resolved to the '" <> sansPrefix <> "' package"
   pure found
 
 

--- a/test/fixtures/spago-install-purescript-prefix-stderr.txt
+++ b/test/fixtures/spago-install-purescript-prefix-stderr.txt
@@ -1,4 +1,4 @@
-[33m[warn] [0mThe package 'purescript-newtype' was not found in your package set, but 'newtype' was. Using that instead.[0m
+[34m[info] [0mThe package 'purescript-newtype' was resolved to the 'newtype' package[0m
 [34m[info] [0mInstalling 1 dependencies.[0m
 [34m[info] [0mSearching for packages cache metadata..[0m
 [34m[info] [0mRecent packages cache metadata found, using it..[0m


### PR DESCRIPTION
Fix #570
