### PR TITLE
Removed fixed UTF-8 encoding, for windows 10, fixes #533 [WIP]

### DIFF
--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -411,7 +411,7 @@ runWithEnv GlobalOptions{..} app = do
 main :: IO ()
 main = do
   -- We always want to run in UTF8 anyways
-  GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
+  -- GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
   -- Stop `git` from asking for input, not gonna happen
   -- We just fail instead. Source:
   -- https://serverfault.com/questions/544156


### PR DESCRIPTION
### Description of the change

This pull request is just to make more visible the workaround to #533 that make Spago work with Windows 10, as commented by @kakkun61 (https://github.com/purescript/spago/issues/533#issuecomment-569484700) . 
I have just removed the fixation of UTF-8 encoding in the main.

Additionally, I have made a Release with that change to make it easy to others: https://github.com/gibranrosa/spago/releases/tag/0.14-windows10

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
