### PR TITLE
Fixup for compiling with ghc-8.8.2

### DIFF
--- a/app/Curator.hs
+++ b/app/Curator.hs
@@ -717,7 +717,7 @@ runWithCwd cwd cmd = do
 getLatestCommitTime :: GHC.IO.FilePath -> Curator Time.UTCTime
 getLatestCommitTime path = do
   (_code, out, _err) <- runWithCwd path "git show -s --format=%ci"
-  Time.parseTimeM True Time.defaultTimeLocale "%Y-%m-%d %H:%M:%S %z" $ Text.unpack out
+  liftIO $ Time.parseTimeM True Time.defaultTimeLocale "%Y-%m-%d %H:%M:%S %z" $ Text.unpack out
 
 
 withAST :: (MonadIO m, MonadReader env m, HasLogFunc env) => Text -> (Expr -> m Expr) -> m ()


### PR DESCRIPTION
GHC-8.8.2 has gone ahead with the MonadFail proposal and removed the `fail` method from the `Monad` class, in favor of the `fail` method in the `MonadFail` class:

https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.8#base-41300

`parseTimeM` requires `MonadFail`:

```haskell
parseTimeM :: (
#if MIN_VERSION_base(4,9,0)
    MonadFail m
#else
    Monad m
#endif
    , ParseTime t) =>
             Bool       -- ^ Accept leading and trailing whitespace?
          -> TimeLocale -- ^ Time locale.
          -> String     -- ^ Format string.
          -> String     -- ^ Input string.
          -> m t    -- ^ Return the time value, or fail if the input could
                        -- not be parsed using the given format.
```

https://hackage.haskell.org/package/time-1.9.3/docs/Data-Time-Format.html#v:parseTimeM

In `app/Curator.hs`, the `Curator` type is an alias around `RIO`, which does _not_ have an instance for `MonadFail`, so `parseTimeM` cannot be used here.

This PR changes the call to `parseTimeM` to behave as if it were `Bool -> TimeLocale -> String -> String -> IO t`.  This works because `IO` does have an instance for `MonadFail`.

This should be functionality equivalent to what was already happening.  It should also work with GHC-8.8 and previous GHCs.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
