### PR TITLE
Upgrade LTS (upgrades GHC to 8.6.5)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.21
+resolver: lts-14.20
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
I tested this and spago could build and run. This helps keep it in line with the current version of GHC available in NixOS as well.

### Description of the change

Upgrade Stackage LTS version and GHC version. 

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
