### PR TITLE
Ensure `psci-support` is installed when starting the repl

### DIFF
--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -36,11 +36,11 @@ compile sourcePaths extraArgs = do
     "Failed to build."
 
 -- TODO: this should use HasPurs
-repl :: [SourcePath] -> [PursArg] -> IO ()
-repl sourcePaths extraArgs = do
+repl :: Text -> [SourcePath] -> [PursArg] -> IO ()
+repl purs sourcePaths extraArgs = do
   let paths = Text.intercalate " " $ surroundQuote <$> map unSourcePath sourcePaths
       args = Text.intercalate " " $ map unPursArg extraArgs
-      cmd = "purs repl " <> paths <> " " <> args
+      cmd = purs <> " repl " <> paths <> " " <> args
 
   viewShell $ callCommand $ Text.unpack cmd
 


### PR DESCRIPTION
Error message:

```
$ spago repl
[error] The package called 'psci-support' needs to be installed for the repl to work properly.
[error] Run `spago install psci-support` to add it to your dependencies.

```

Fix #550