### PR TITLE
Use rio-0.1.13.0 for the mapRIO function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Breaking changes (😱!!!):
+
+New features:
+
+Bugfixes:
+
+Other improvements:
+- Deps: upgrade `rio` to `0.1.13.0` (#616)
+
 ## [0.15.1] - 2020-04-15
 
 Breaking changes (😱!!!):

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -65,7 +65,6 @@ module Spago.Prelude
   , appendonly
   , docsSearchVersion
   , githubTokenEnvVar
-  , mapRIO
   ) where
 
 
@@ -232,9 +231,3 @@ findExecutableOrDie cmd = do
   Directory.findExecutable cmd >>= \case 
     Nothing -> die [ "Executable was not found in path: " <> displayShow cmd ]
     Just path -> pure $ Text.pack path
-
--- | Lift one RIO env to another.
-mapRIO :: (outer -> inner) -> RIO inner a -> RIO outer a
-mapRIO f m = do
-  outer <- ask
-  runRIO (f outer) m

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - dotgen-0.4.2
 - megaparsec-7.0.3
 - repline-0.2.1.0
-- rio-0.1.12.0
+- rio-0.1.13.0
 - rio-orphans-0.1.1.0
 - serialise-0.2.1.0
 - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -117,12 +117,12 @@ packages:
   original:
     hackage: repline-0.2.1.0
 - completed:
-    hackage: rio-0.1.12.0@sha256:a0b42682a455ffde6a4d894b135117e379aea7ed1810c2cfed471b8f5879968c,3633
+    hackage: rio-0.1.13.0@sha256:778bb30261be9789c6c848bfbdb914e4cf7490159964217e0d853dc047868cd1,3633
     pantry-tree:
       size: 4745
-      sha256: 340566441c9d1087f661fb51f95a080ffdf2da8fce6b4b8f86f158f4195894f5
+      sha256: 3f9bf28c37d33cfbeea5664025218987023b03f01f55697466c3db3074edefff
   original:
-    hackage: rio-0.1.12.0
+    hackage: rio-0.1.13.0
 - completed:
     hackage: rio-orphans-0.1.1.0@sha256:15600084c56ef4e1f22ac2091d10fa6ed62f01f531d819c6a5a19492212a76c9,1612
     pantry-tree:


### PR DESCRIPTION
### Description of the change

I'm attempting to get `spago` compiling in nixpkgs.  nixpkgs uses a newer version of `rio`.  I'm getting the following `rio`-related error:

```
Building library for spago-0.15.1..

on the commandline: warning:
    -XAutoDeriveTypeable is deprecated: Typeable instances are created automatically for all types since GHC 8.2.

on the commandline: warning:
    -XMonadFailDesugaring is deprecated: MonadFailDesugaring is now the default behavior
[ 1 of 29] Compiling Paths_spago      ( dist/build/autogen/Paths_spago.hs, dist/build/Paths_spago.o )
[ 2 of 29] Compiling Spago.Prelude    ( src/Spago/Prelude.hs, dist/build/Spago/Prelude.o )

src/Spago/Prelude.hs:68:5: error:
    Conflicting exports for ‘mapRIO’:
       ‘module X’ exports ‘X.mapRIO’
         imported from ‘RIO’ at src/Spago/Prelude.hs:100:1-99
         (and originally defined in ‘rio-0.1.15.0:RIO.Prelude.RIO’)
       ‘Spago.Prelude.mapRIO’ exports ‘Spago.Prelude.mapRIO’
         defined at src/Spago/Prelude.hs:238:1
   |
68 |   , Spago.Prelude.mapRIO
   |     ^^^^^^^^^^^^^^^^^^^^
```

This is possible to fix by using a newer `rio` version here in spago, and getting the `mapRIO` function directly from `rio` (instead of redefining it in `spago`).

I'm not sure if you're fine with accepting these kind of dependency version bumps, but if you are, it slightly helps us package spago in nixpkgs.

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
