### PR TITLE
Add note about using single quotes for --purs-args

### DIFF
--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -156,7 +156,7 @@ parser = do
 
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `ls packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
-    pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Argument to pass to purs"
+    pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Arguments to pass to purs compile. Wrap in single quotes."
     buildOptions  = BuildOptions <$> watch <*> clearScreen <*> sourcePaths <*> srcMapFlag <*> noInstall
                     <*> pursArgs <*> depsOnly <*> beforeCommands <*> thenCommands <*> elseCommands
 

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -156,7 +156,7 @@ parser = do
 
     packageName     = CLI.arg (Just . PackageName) "package" "Specify a package name. You can list them with `ls packages`"
     packageNames    = many $ CLI.arg (Just . PackageName) "package" "Package name to add as dependency"
-    pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Arguments to pass to purs compile. Wrap in single quotes."
+    pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Arguments to pass to purs compile. Wrap in quotes."
     buildOptions  = BuildOptions <$> watch <*> clearScreen <*> sourcePaths <*> srcMapFlag <*> noInstall
                     <*> pursArgs <*> depsOnly <*> beforeCommands <*> thenCommands <*> elseCommands
 


### PR DESCRIPTION
It's confusing when porting commands from other tools which don't require quotes around purs args. For example:
This works:
```
psc-package build -- --codegen js,corefn
```
This does not:
```
spago build --purs-args --codegen js,corefn
```
This is required instead:
```
spago build --purs-args '--codegen js,corefn'
```