### PR TITLE
Don't use absolute paths for executables

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -83,7 +83,7 @@ library:
   - bytestring
   - Cabal
   - containers
-  - dhall >= 1.29.0
+  - dhall >= 1.31.1
   - directory >= 1.3.4.0
   - either
   - exceptions
@@ -104,7 +104,7 @@ library:
   - prettyprinter
   - process
   - retry
-  - rio
+  - rio >= 0.1.13.0
   - rio-orphans
   - safe
   - semver-range

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -228,6 +228,9 @@ pretty = PrettyText.renderStrict
 --   or die trying
 findExecutableOrDie :: HasLogFunc env => String -> RIO env Text
 findExecutableOrDie cmd = do
-  Directory.findExecutable cmd >>= \case 
+  Directory.findExecutable cmd >>= \case
     Nothing -> die [ "Executable was not found in path: " <> displayShow cmd ]
-    Just path -> pure $ Text.pack path
+    -- Note: we ignore the path and just return the input because the one we get
+    -- here is absolute, and Windows doesn't seem to be able to deal with that.
+    -- See: https://github.com/purescript/spago/issues/635
+    Just _path -> pure $ Text.pack cmd


### PR DESCRIPTION
Fix #635 

We just return the relative path that we provide in the first place instead.