### PR TITLE
Fix typos in bundle-app help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugfixes:
 
 Other improvements:
 - Deps: upgrade `rio` to `0.1.13.0` (#616)
+- Fix typos in `spago bundle-app` help message
 
 ## [0.15.2] - 2020-04-15
 

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -119,8 +119,8 @@ parser = do
       in CLI.optional $ CLI.opt wrap "global-cache" 'c' "Configure the global caching behaviour: skip it with `skip` or force update with `update`"
 
     beforeCommands = many $ CLI.opt Just "before" 'b' "Commands to run before a build."
-    thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successfull build."
-    elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessfull build."
+    thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successful build."
+    elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessful build."
     versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     quiet       = CLI.switch "quiet" 'q' "Suppress all spago logging"


### PR DESCRIPTION
### Description of the change

Fix typo's in the `spago bundle-app` help message

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
