### PR TITLE
Fix README: webpack.config.js template

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,7 +962,7 @@ To start a project using Spago and Parcel together, here's the commands and file
       new HtmlWebpackPlugin({
         title: 'purescript-webpack-example',
         template: 'index.html',
-        inject: false
+        inject: false  // See stackoverflow.com/a/38292765/3067181
       })
     ].concat(plugins)
   };

--- a/README.md
+++ b/README.md
@@ -961,7 +961,8 @@ To start a project using Spago and Parcel together, here's the commands and file
       }),
       new HtmlWebpackPlugin({
         title: 'purescript-webpack-example',
-        template: 'index.html'
+        template: 'index.html',
+        inject: false
       })
     ].concat(plugins)
   };


### PR DESCRIPTION
### Description of the change

In README we suggest to manually include the bundle script in `index.html` but in `webpack.config.js` we do not tell `HtmlWebpackPlugin` to avoid injection. As a result, the bundle will be injected twice.

See https://stackoverflow.com/a/38292765/3067181
