### PR TITLE
Remove shorthands for --before, --then, and --else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Breaking changes (😱!!!):
   Both `then` and `target` had the shorthand `t`, so the shorthand for `then` was removed.
   Since `then`, `before`, and `else` are all shared between several commands, it seemed
   natural to remove the shorthands for the other shared commands too, so as to not cause 
-  future name shorthand conflicts.
+  future shorthand name conflicts.
 
 Other improvements:
 - Docs: updated package addition/overriding syntax to use `with` syntax (#661)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Breaking changes (😱!!!):
+- **Remove shorthands for `before`, `then`, and `else` (#664)**
+
+  Both `then` and `target` had the shorthand `t`, so the shorthand for `then` was removed.
+  Since `then`, `before`, and `else` are all shared between several commands, it seemed
+  natural to remove the shorthands for the other shared commands too, so as to not cause 
+  future name shorthand conflicts.
+
 Other improvements:
 - Docs: updated package addition/overriding syntax to use `with` syntax (#661)
 

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -118,9 +118,10 @@ parser = do
             _ -> Nothing
       in CLI.optional $ CLI.opt wrap "global-cache" 'c' "Configure the global caching behaviour: skip it with `skip` or force update with `update`"
 
-    beforeCommands = many $ CLI.opt Just "before" 'b' "Commands to run before a build."
-    thenCommands   = many $ CLI.opt Just "then" 't' "Commands to run following a successful build."
-    elseCommands   = many $ CLI.opt Just "else" 'e' "Commands to run following an unsuccessful build."
+    beforeCommands = many $ Opts.strOption (Opts.long "before" <> Opts.help "Commands to run before a build.")
+    thenCommands = many $ Opts.strOption (Opts.long "then" <> Opts.help "Commands to run following a successful build.")
+    elseCommands = many $ Opts.strOption (Opts.long "else" <> Opts.help "Commands to run following an unsuccessful build.")
+
     versionBump = CLI.arg Spago.Version.parseVersionBump "bump" "How to bump the version. Acceptable values: 'major', 'minor', 'patch', or a version (e.g. 'v1.2.3')."
 
     quiet       = CLI.switch "quiet" 'q' "Suppress all spago logging"


### PR DESCRIPTION
### Description of the change

Remove the shorthand forms of `--before`, `--then`, and `--else` (See #651 for some context).

Fixes #651.

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
