### PR TITLE
Supply --run argument to alt backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes (😱!!!):
 
 Other improvements:
 - Docs: updated package addition/overriding syntax to use `with` syntax (#661)
+- Pass main function argument to `--run` for alternate backends
 
 ## [0.15.3] - 2020-06-15
 

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -233,8 +233,10 @@ runBackend maybeBackend moduleName maybeSuccessMessage failureMessage buildOpts 
       Turtle.system processWithStdin empty >>= \case
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage
         ExitFailure n -> die [ display failureMessage <> "exit code: " <> repr n ]
-    backendAction backend =
-      Turtle.proc backend (["--run" {-, unModuleName moduleName-}] <> fmap unPursArg extraArgs) empty >>= \case
+    backendAction backend = do
+      let args :: [Text] = ["--run", unModuleName moduleName <> ".main"] <> fmap unPursArg extraArgs
+      logDebug $ display $ "Running command `" <> backend <> " " <> Text.unwords args <> "`"
+      Turtle.proc backend args empty >>= \case
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage
         ExitFailure n -> die [ display failureMessage <> "Backend " <> displayShow backend <> " exited with error:" <> repr n ]
 


### PR DESCRIPTION
### Description of the change

Add `--run Module.main` to the alt backend invocation (applies to `run` and `test`). As the main module is already resolved there is no need to answer the question in #434 about the default to `--run`, `spago` can just always supply it. Note that as per the proposed API on #434, the main function is also passed, since `spago` already cares about this for JS this seems appropriate to me.

cc @andyarvanitis  @csicar @thautwarm

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
