### PR TITLE
Allow upgrade of alternative package sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ New features:
 Other improvements:
 - Docs: updated package addition/overriding syntax to use `with` syntax (#661)
 - Pass main function argument to `--run` for alternate backends
+- Support `upgrade set` for alternative package-set repositories
 
 ## [0.15.3] - 2020-06-15
 

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -63,6 +63,11 @@ cannotFindPackages = makeMessage
   , "otherwise you might want to run `spago init` to initialize a new package set file."
   ]
 
+cannotFindPackageImport :: Text
+cannotFindPackageImport = makeMessage
+  [ "Cannot find a package set import in your " <> surroundQuote "packages.dhall" <> "."
+  ]
+
 foundExistingProject :: Text -> Text
 foundExistingProject pathText = makeMessage
   [ "Found a " <> surroundQuote pathText <> " file, skipping copy. Run `spago init --force` if you wish to overwrite it."

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -4,7 +4,7 @@ import           Control.Concurrent (threadDelay)
 import qualified Data.Text          as Text
 import           Prelude            hiding (FilePath)
 import qualified System.IO.Temp     as Temp
-import           Test.Hspec         (Spec, around_, describe, it, shouldBe, shouldNotSatisfy,
+import           Test.Hspec         (Spec, around_, describe, it, shouldBe, shouldNotBe, shouldNotSatisfy,
                                      shouldReturn, shouldSatisfy)
 import           Turtle             (ExitCode (..), cd, cp, decodeString, empty, encodeString,
                                      mkdir, mktree, mv, pwd, readTextFile, rm, shell,
@@ -576,6 +576,14 @@ spec = around_ setup $ do
       newPackages <- Text.strip <$> readTextFile "packages.dhall"
       newPackages `shouldBe` packageSetUrl
 
+    it "Spago should migrate a package set from an alternative repository from src/packages.dhall" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      writeTextFile "packages.dhall" "https://github.com/purerl/package-sets/releases/download/erl-0.13.6-20200713/packages.dhall sha256:6b1dcfe05ee95229b654462bf5d36864f9a0dfbc2ac120192aaa25f9fceb9967"
+      spago ["-v", "upgrade-set"] >>= shouldBeSuccess
+      newPackages <- Text.strip <$> readTextFile "packages.dhall"
+      newPackages `shouldNotBe` "https://github.com/purerl/package-sets/releases/download/erl-0.13.6-20200713/packages.dhall"
+      newPackages `shouldSatisfy` Text.isPrefixOf "https://github.com/purerl/package-sets/releases/download"
 
   describe "spago run" $ do
 


### PR DESCRIPTION
### Description of the change

Allow upgrade via `spago upgrade-set` when the package set is other than `purescript/package-sets`.

Motivation:
* Alternate backends which use an alternative package set (https://github.com/purerl/package-sets)
* Organisation-private package sets

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
