### PR TITLE
Ensure the existence of global cache directory

### DIFF
--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -149,7 +149,9 @@ getMetadata cacheFlag = do
 --   - (on Windows) the folder pointed by `LocalAppData`
 getGlobalCacheDir :: MonadIO m => m FilePath.FilePath
 getGlobalCacheDir = do
-  liftIO $ getXdgDirectory XdgCache "spago" <|> pure ".spago-global-cache"
+  globalCache <- liftIO $ getXdgDirectory XdgCache "spago" <|> pure ".spago-global-cache"
+  assertDirectory globalCache
+  pure globalCache
 
 
 -- | Fetch the tarball at `archiveUrl` and unpack it into `destination`

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -147,7 +147,7 @@ getMetadata cacheFlag = do
 --   `$XDG_CACHE_HOME`, otherwise it uses:
 --   - (on Linux/MacOS) the folder pointed by `$HOME/.cache`, or
 --   - (on Windows) the folder pointed by `LocalAppData`
-getGlobalCacheDir :: (MonadIO m, MonadThrow m, HasLogFunc env, MonadReader env m) => m FilePath.FilePath
+getGlobalCacheDir :: (MonadIO m, HasLogFunc env, MonadReader env m) => m FilePath.FilePath
 getGlobalCacheDir = do
   globalCache <- liftIO $ getXdgDirectory XdgCache "spago" <|> pure ".spago-global-cache"
   assertDirectory globalCache

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -147,7 +147,7 @@ getMetadata cacheFlag = do
 --   `$XDG_CACHE_HOME`, otherwise it uses:
 --   - (on Linux/MacOS) the folder pointed by `$HOME/.cache`, or
 --   - (on Windows) the folder pointed by `LocalAppData`
-getGlobalCacheDir :: MonadIO m => m FilePath.FilePath
+getGlobalCacheDir :: (MonadIO m, MonadThrow m, HasLogFunc env, MonadReader env m) => m FilePath.FilePath
 getGlobalCacheDir = do
   globalCache <- liftIO $ getXdgDirectory XdgCache "spago" <|> pure ".spago-global-cache"
   assertDirectory globalCache

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -188,6 +188,7 @@ assertDirectory directory = do
       unless (accessible permissions) $ do
         die [ "Directory " <> displayShow directory <> " is not accessible. " <> displayShow permissions ]
     else do
+      logDebug $ "Directory " <> displayShow directory <> " does not exist, creating..."
       assertDirectory (FilePath.takeDirectory directory)
 
       Directory.createDirectory directory

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -166,7 +166,7 @@ cptree from to' = Turtle.cptree (Turtle.decodeString from) (Turtle.decodeString 
 
 
 -- | Code from: https://github.com/dhall-lang/dhall-haskell/blob/d8f2787745bb9567a4542973f15e807323de4a1a/dhall/src/Dhall/Import.hs#L578
-assertDirectory :: (MonadIO m, MonadThrow m, HasLogFunc env, MonadReader env m) => FilePath.FilePath -> m ()
+assertDirectory :: (MonadIO m, HasLogFunc env, MonadReader env m) => FilePath.FilePath -> m ()
 assertDirectory directory = do
   let private = transform Directory.emptyPermissions
         where

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -42,7 +42,9 @@ withEnv GlobalOptions{..} app = do
 
     globalCache <- runRIO logFunc' $ do
       logDebug "Running `getGlobalCacheDir`"
-      Cache.getGlobalCacheDir
+      globalCache' <- Cache.getGlobalCacheDir
+      assertDirectory globalCache'
+      pure globalCache'
 
     let env = Env
           { envLogFunc = logFunc'

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -42,9 +42,7 @@ withEnv GlobalOptions{..} app = do
 
     globalCache <- runRIO logFunc' $ do
       logDebug "Running `getGlobalCacheDir`"
-      globalCache' <- Cache.getGlobalCacheDir
-      assertDirectory globalCache'
-      pure globalCache'
+      Cache.getGlobalCacheDir
 
     let env = Env
           { envLogFunc = logFunc'

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -13,7 +13,7 @@ import           Utils              (checkFileHasInfix, checkFixture, checkFileE
                                      readFixture, runFor, shouldBeFailure,
                                      shouldBeFailureStderr, shouldBeSuccess, shouldBeSuccessOutput,
                                      shouldBeSuccessOutputWithErr, shouldBeSuccessStderr, spago,
-                                     withCwd)
+                                     withCwd, withEnvVar)
 
 
 setup :: IO () -> IO ()
@@ -704,3 +704,8 @@ spec = around_ setup $ do
       mv "packages.dhall" "packages-old.dhall"
       writeTextFile "packages.dhall" $ "abcdef"
       spago ["verify-set"] >>= shouldBeFailure
+
+  describe "global cache" $ do
+    it "Spago should create global cache directory if it does not exist" $ do
+      withEnvVar "XDG_CACHE_HOME" "./nonexisting-cache" $
+        spago ["repl"] >>= shouldBeSuccess

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -20,10 +20,12 @@ module Utils
   , shouldBeEmptySuccess
   , spago
   , withCwd
+  , withEnvVar
   ) where
 
 import qualified Control.Concurrent as Concurrent
 import qualified Control.Exception  as Exception
+import           Data.Maybe         (fromMaybe)
 import qualified Data.Text          as Text
 import qualified Data.Text.Encoding as Text.Encoding
 import           Data.Text.Encoding.Error (lenientDecode)
@@ -31,8 +33,8 @@ import           Prelude            hiding (FilePath)
 import           System.Directory   (removePathForcibly, doesFileExist)
 import qualified System.Process     as Process
 import           Test.Hspec         (HasCallStack, shouldBe, shouldSatisfy)
-import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString, inproc,
-                                     limit, pwd, readTextFile, strict)
+import           Turtle             (ExitCode (..), FilePath, Text, cd, empty, encodeString, export,
+                                     inproc, limit, need, pwd, readTextFile, strict)
 import qualified Turtle.Bytes
 
 
@@ -40,6 +42,14 @@ withCwd :: FilePath -> IO () -> IO ()
 withCwd dir cmd = do
   oldDir <- pwd
   Exception.bracket_ (cd dir) (cd oldDir) cmd
+
+withEnvVar :: Text -> Text -> IO () -> IO ()
+withEnvVar var value cmd = do
+  oldValue <- need var
+  Exception.bracket_
+    (export var value)
+    (export var (fromMaybe "" oldValue))
+    cmd
 
 proc :: Text -> [Text] -> IO (ExitCode, Text, Text)
 proc cmd args = do


### PR DESCRIPTION
### Description of the change

Fixes #667 

Some commands (i.e. `spago init`) trigger the creation of global cache directory, while some others (i.e. `spago repl`) don't. With this PR, the existence of global cache directory is checked for every Spago command, and the directory is created if it doesn't exist already.
