### PR TITLE
Make outputs of `version` and `--version` uniform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ New features:
 - Ignore .gitignore files in `--watch` by default (#665)
 - Add `--allow-ignored` to allow files ignored via .gitignore to trigger rebuilds (#665)
 
+Bugfixes:
+- Make the output of `spago --version` the same with `spago version` (#675)
+
 Other improvements:
 - Docs: updated package addition/overriding syntax to use `with` syntax (#661)
 - Pass main function argument to `--run` for alternate backends

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -8,7 +8,6 @@ import qualified Paths_spago         as Pcli
 import           Main.Utf8           (withUtf8)
 import           Spago.CLI           (Command(..))
 
-import qualified Data.Text           as Text
 import qualified System.Environment  as Env
 import qualified Spago.Build
 import qualified Spago.GitHub
@@ -31,10 +30,19 @@ main = withUtf8 $ do
   Env.setEnv "GIT_TERMINAL_PROMPT" "0"
 
   (command, globalOptions@GlobalOptions{..}) 
-    <- CLI.optionsExt "" "" "Spago - manage your PureScript projects" (Text.pack spagoVersion) CLI.parser
+    <- CLI.options "Spago - manage your PureScript projects" CLI.parser
+
+  let handleDefault :: MonadIO m => ShowVersion -> m ()
+      handleDefault = \case
+        DoShowVersion -> CLI.echo spagoVersion *> exitSuccess
+        NoShowVersion -> pure ()
 
   Run.withEnv globalOptions $
     case command of
+
+      -- ### Commands that need no env
+      Default shouldShowVersion
+        -> handleDefault shouldShowVersion
 
       -- ### Commands that need only a basic global env
       Init force noComments

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -166,6 +166,10 @@ parser = do
     buildOptions  = BuildOptions <$> watch <*> clearScreen <*> allowIgnored <*> sourcePaths <*> srcMapFlag <*> noInstall
                     <*> pursArgs <*> depsOnly <*> beforeCommands <*> thenCommands <*> elseCommands
 
+    -- Opts.flag' creates a parser with no default value. This is intended.
+    -- We want this parser to fail if it does not get a --version flag, rather
+    -- than defaulting to NoShowVersion.  We rely on the parser failure to show
+    -- the help message.
     versionOpt  = Opts.flag' DoShowVersion (Opts.long "version" <> Opts.help "Show spago version")
 
     -- Note: by default we limit concurrency to 20

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -1,6 +1,6 @@
 module Spago.CLI
   ( module Spago.CLI
-  , CLI.optionsExt
+  , CLI.options
   ) where
 
 import Spago.Prelude
@@ -21,9 +21,12 @@ import Spago.Version (VersionBump (..))
 
 -- | Commands that this program handles
 data Command
+
+  -- | Default catch-all command
+  = Default ShowVersion
   
   -- | Initialize a new project
-  = Init Force TemplateComments
+  | Init Force TemplateComments
 
   -- | Install (download) dependencies defined in spago.dhall
   | Install [PackageName]
@@ -109,6 +112,7 @@ parser = do
     <|> publishCommands
     <|> otherCommands
     <|> oldCommands
+    <|> ( Default <$> versionOpt )
   pure (command, opts)
   where
     cacheFlag =
@@ -161,6 +165,8 @@ parser = do
     pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Arguments to pass to purs compile. Wrap in quotes."
     buildOptions  = BuildOptions <$> watch <*> clearScreen <*> allowIgnored <*> sourcePaths <*> srcMapFlag <*> noInstall
                     <*> pursArgs <*> depsOnly <*> beforeCommands <*> thenCommands <*> elseCommands
+
+    versionOpt  = Opts.flag' DoShowVersion (Opts.long "version" <> Opts.help "Show spago version")
 
     -- Note: by default we limit concurrency to 20
     globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> usePsa

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -126,6 +126,8 @@ data ClearScreen = DoClear | NoClear
 -- | Flag to allow files ignored via `.gitignore` to trigger a rebuild
 data AllowIgnored = DoAllowIgnored | NoAllowIgnored
 
+data ShowVersion = DoShowVersion | NoShowVersion
+
 
 data BuildOptions = BuildOptions
   { shouldWatch    :: Watch


### PR DESCRIPTION
### Description of the change

Fixes #649 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)