### PR TITLE
Drop dependency on libtinfo

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -44,3 +44,8 @@ extra-deps:
 allow-newer: true
 nix:
   packages: [zlib]
+
+# This is so we don't depend on libtinfo
+flags:
+  haskeline:
+    terminfo: false


### PR DESCRIPTION
As per title, we disable the inclusion of the `terminfo` library when compiling, which in turn removes our dependency on `libtinfo`. This should remove a whole lot of issues about `libtinfo` compatibiity across distros, and remove the _urgent_ need to have a static build.

This is a harmless change, since we inherit the dependency transitively from Dhall, which includes that for the REPL, which we don't use anywhere.