### PR TITLE
fix: to correct value of pursArgs in findFlag in Path.hs

### DIFF
--- a/src/Spago/Command/Path.hs
+++ b/src/Spago/Command/Path.hs
@@ -53,11 +53,12 @@ getOutputPath buildOpts = do
 -- | Try to find the content of a certain flag in a list of PursArgs
 findFlag :: Char -> Text -> [PursArg] -> Maybe Text
 findFlag char string = \case
-  [] -> Nothing
-  [_] -> Nothing
-  (x:y:xs) -> if isFlag x
-              then Just (unPursArg y)
-              else findFlag char string (y : xs)
+  (x:xs) -> if isFlag x
+              then case Text.words (unPursArg x) of
+                (_:value:_) -> Just value
+                _ -> Nothing
+              else findFlag char string xs
+  _ -> Nothing
   where 
     isFlag :: PursArg -> Bool
     isFlag (PursArg a)

--- a/src/Spago/Command/Path.hs
+++ b/src/Spago/Command/Path.hs
@@ -1,4 +1,4 @@
-module Spago.Command.Path (showPaths, getOutputPath) where
+module Spago.Command.Path (showPaths, getOutputPath, findFlag) where
 
 import Spago.Prelude
 import Spago.Env
@@ -43,7 +43,7 @@ getOutputPath buildOpts = do
     Just path -> Text.unpack path
 
 
--- TODO tests:
+-- tests are followings: See test/Spago/Command/PathSpec.hs
 -- ["-o", "something"]
 -- ["--output", "something"]
 -- ["--output something"]
@@ -54,18 +54,32 @@ getOutputPath buildOpts = do
 findFlag :: Char -> Text -> [PursArg] -> Maybe Text
 findFlag char string = \case
   (x:xs) -> if isFlag x
-              then case Text.words (unPursArg x) of
-                (_:value:_) -> Just value
+              then case xs of
+                (y:ys) -> Just (unPursArg y)
                 _ -> Nothing
-              else findFlag char string xs
+              else if hasFlag x
+                then case Text.words (unPursArg x) of
+                  [word] -> case Text.split (=='=') word of
+                    [one]       -> Nothing
+                    [key,value] -> Just value
+                  (_:value:_) -> Just value
+                  _ -> Nothing
+                else findFlag char string xs
   _ -> Nothing
-  where 
+  where
     isFlag :: PursArg -> Bool
-    isFlag (PursArg a)
+    isFlag (PursArg word)
+      =  word == (Text.pack ['-', char])
+      || word == ("--" <> string)
+    hasFlag :: PursArg -> Bool
+    hasFlag (PursArg a)
       =  firstWord == (Text.pack ['-', char])
       || firstWord == ("--" <> string)
         where
           firstWord
             = fromMaybe "" $ case Text.words a of
                 []       -> Nothing
+                [word]   -> case Text.split (=='=') word of
+                  [one]       -> Just one
+                  [key,value] -> Just key
                 (word:_) -> Just word

--- a/src/Spago/Command/Path.hs
+++ b/src/Spago/Command/Path.hs
@@ -43,7 +43,7 @@ getOutputPath buildOpts = do
     Just path -> Text.unpack path
 
 
--- tests are followings: See test/Spago/Command/PathSpec.hs
+-- See tests in: test/Spago/Command/PathSpec.hs
 -- ["-o", "something"]
 -- ["--output", "something"]
 -- ["--output something"]

--- a/src/Spago/Command/Path.hs
+++ b/src/Spago/Command/Path.hs
@@ -55,13 +55,13 @@ findFlag :: Char -> Text -> [PursArg] -> Maybe Text
 findFlag char string = \case
   (x:xs) -> if isFlag x
               then case xs of
-                (y:ys) -> Just (unPursArg y)
+                (y:_) -> Just (unPursArg y)
                 _ -> Nothing
               else if hasFlag x
                 then case Text.words (unPursArg x) of
                   [word] -> case Text.split (=='=') word of
-                    [one]       -> Nothing
-                    [key,value] -> Just value
+                    [_,value] -> Just value
+                    _           -> Nothing
                   (_:value:_) -> Just value
                   _ -> Nothing
                 else findFlag char string xs
@@ -81,5 +81,6 @@ findFlag char string = \case
                 []       -> Nothing
                 [word]   -> case Text.split (=='=') word of
                   [one]       -> Just one
-                  [key,value] -> Just key
+                  [key,_]     -> Just key
+                  _           -> Nothing
                 (word:_) -> Just word

--- a/test/Spago/Command/PathSpec.hs
+++ b/test/Spago/Command/PathSpec.hs
@@ -1,0 +1,32 @@
+module Spago.Command.PathSpec (spec) where
+
+import            Prelude
+import            Test.Hspec
+
+import            Spago.Prelude hiding (link)
+import            Spago.Env
+import qualified  Spago.Command.Path   as Path
+
+spec :: Spec
+spec = do
+  describe "Path findFlag" $ do
+    it "[\"-o\", \"something\"]" $ do
+      let a = fromMaybe "" $ Path.findFlag 'o' "output" [PursArg "-o" , PursArg "something"]
+      let b = "something"
+      a `shouldBe` b
+    it "[\"--output\", \"something\"]" $ do
+      let a = fromMaybe "" $ Path.findFlag 'o' "output" [PursArg "--output" , PursArg "something"]
+      let b = "something"
+      a `shouldBe` b
+    it "[\"-o something\"]" $ do
+      let a = fromMaybe "" $ Path.findFlag 'o' "output" [PursArg "-o something"]
+      let b = "something"
+      a `shouldBe` b
+    it "[\"--output something\"]" $ do
+      let a = fromMaybe "" $ Path.findFlag 'o' "output" [PursArg "--output something"]
+      let b = "something"
+      a `shouldBe` b
+    it "[\"--output=something\"]" $ do
+      let a = fromMaybe "" $ Path.findFlag 'o' "output" [PursArg "--output=something"]
+      let b = "something"
+      a `shouldBe` b


### PR DESCRIPTION
### Description of the change

This PR is to fix the bug that the user can not `spago run` command when he specifies the output directory different from `output`.

- The Issue I found

Support user wants to specify output directory, for example, `output2` directory.

The build can be done by the command
```
$ spago build -u "-o output2"
```

However, the run leads to error by the command.
```
$ spago run -u "-o output2"
```

- Reason and how to fix in this PR
 
This issue is because `findFlag` function in `Path.hs` has a problem.
If we use
```
$ spago run -u "-o output2"
```
, the `pursArgs` is `["-o output2"]`, not `["-o", "output2"]`.
 
Therefore `(x:y:xs)` can not match the `y = "output2"`.



### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
