### PR TITLE
add backend args flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `backend-args` as alias to `node-args`, to clarify that the args are
+- Add `exec-args` as alias to `node-args`, to clarify that the args are
   forwarded to whichever backend is being targeted (go, js, etc), not
   exclusively node.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `backend-args` as alias to `node-args`, to clarify that the args are
+  forwarded to whichever backend is being targeted (go, js, etc), not
+  exclusively node.
+
 ## [0.18.0] - 2020-12-07
 
 Breaking changes (😱!!!):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ and respect and do not harass or belittle others.
 
 ## What is the correct way to ask a question?
 
-It's ok to ask questions by [opening an issue][spago-issues]!  
+It's ok to ask questions by [opening an issue][spago-issues]!
 I ([@f-f][f-f]) am also on the [Functional Programming Slack][fp-slack], so you can also ask
 questions in the `#purescript` and `#purescript-beginners` channels.
 
@@ -81,6 +81,9 @@ $ npm install -g bower
 
 # This runs the tests which make use of the `spago` executable
 $ stack test
+
+# A single test can be running by providing a pattern to the 'match' flag
+$ stack test --test-arguments='--match "/Spago/spago run/Spago should use backend-args"'
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ $ npm install -g bower
 $ stack test
 
 # A single test can be running by providing a pattern to the 'match' flag
-$ stack test --test-arguments='--match "/Spago/spago run/Spago should use backend-args"'
+$ stack test --test-arguments='--match "/Spago/spago run/Spago should use exec-args"'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ $ spago run --main ModulePath.To.Main
 $ spago run --main ModulePath.To.Main --purs-args "--verbose-errors"
 
 # Or pass arguments to the backend, in this case node
-$ spago run --backend-args "arg1 arg2"
+$ spago run --exec-args "arg1 arg2"
 
 # For versions 18 and below, use `node-args` instead:
 $ spago run --node-args "arg1 arg2"

--- a/README.md
+++ b/README.md
@@ -367,8 +367,12 @@ $ spago run --main ModulePath.To.Main
 # And pass arguments through to `purs compile`
 $ spago run --main ModulePath.To.Main --purs-args "--verbose-errors"
 
-# Or pass arguments to node
+# Or pass arguments to the backend, in this case node
+$ spago run --backend-args "arg1 arg2"
+
+# For versions 18 and below, use `node-args` instead:
 $ spago run --node-args "arg1 arg2"
+
 ```
 
 

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -155,6 +155,7 @@ parser = do
     docsFormat  = CLI.optional $ CLI.opt Purs.parseDocsFormat "format" 'f' "Docs output format (markdown | html | etags | ctags)"
     jobsLimit   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     nodeArgs         = many $ CLI.opt (Just . BackendArg) "node-args" 'a' "Argument to pass to node (run/test only)"
+    backendArgs      = many $ CLI.opt (Just . BackendArg) "backend-args" 'b' "Argument to pass to the backend (run/test only)"
     replPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'D' "Package name to add to the REPL as dependency"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include"
 
@@ -174,7 +175,6 @@ parser = do
     globalOptions = GlobalOptions <$> quiet <*> verbose <*> veryVerbose <*> (not <$> noColor) <*> usePsa
                     <*> jobsLimit <*> configPath <*> cacheFlag
 
-
     initProject =
       ( "init"
       , "Initialize a new sample project, or migrate a psc-package one"
@@ -193,16 +193,19 @@ parser = do
       , Repl <$> replPackageNames <*> sourcePaths <*> pursArgs <*> depsOnly
       )
 
+    firstNonEmpty x y = if null x then y else x
+    execArgs = firstNonEmpty <$> backendArgs <*> nodeArgs
+
     test =
       ( "test"
       , "Test the project with some module, default Test.Main"
-      , Test <$> mainModule <*> buildOptions <*> nodeArgs
+      , Test <$> mainModule <*> buildOptions <*> execArgs
       )
 
     run =
       ( "run"
       , "Runs the project with some module, default Main"
-      , Run <$> mainModule <*> buildOptions <*> nodeArgs
+      , Run <$> mainModule <*> buildOptions <*> execArgs
       )
 
     bundleApp =

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -155,7 +155,7 @@ parser = do
     docsFormat  = CLI.optional $ CLI.opt Purs.parseDocsFormat "format" 'f' "Docs output format (markdown | html | etags | ctags)"
     jobsLimit   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     nodeArgs         = many $ CLI.opt (Just . BackendArg) "node-args" 'a' "Argument to pass to node (run/test only)"
-    backendArgs      = many $ CLI.opt (Just . BackendArg) "backend-args" 'b' "Argument to pass to the backend (run/test only)"
+    backendArgs      = many $ CLI.opt (Just . BackendArg) "exec-args" 'b' "Argument to pass to the backend (run/test only)"
     replPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'D' "Package name to add to the REPL as dependency"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include"
 
@@ -193,8 +193,7 @@ parser = do
       , Repl <$> replPackageNames <*> sourcePaths <*> pursArgs <*> depsOnly
       )
 
-    firstNonEmpty x y = if null x then y else x
-    execArgs = firstNonEmpty <$> backendArgs <*> nodeArgs
+    execArgs = (++) <$> backendArgs <*> nodeArgs
 
     test =
       ( "test"

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -668,13 +668,13 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       shellStrictWithErr "echo wut| spago run" empty >>= shouldBeSuccessOutput "spago-run-passthrough.txt"
 
-    it "Spago should use backend-args" $ do
+    it "Spago should use exec-args" $ do
 
       spago ["init"] >>= shouldBeSuccess
       cp "../fixtures/spago-run-args.purs" "src/Main.purs"
       spago ["install", "node-process"] >>= shouldBeSuccess
       spago ["build"] >>= shouldBeSuccess
-      spago ["run", "--backend-args", "hello world"] >>= shouldBeSuccessOutput "run-args-output.txt"
+      spago ["run", "--exec-args", "hello world"] >>= shouldBeSuccessOutput "run-args-output.txt"
 
     it "Spago should use node-args" $ do
 
@@ -684,13 +684,13 @@ spec = around_ setup $ do
       spago ["build"] >>= shouldBeSuccess
       spago ["run", "--node-args", "hello world"] >>= shouldBeSuccessOutput "run-args-output.txt"
 
-    it "Spago should prefer backend-args" $ do
+    it "Spago should prefer exec-args" $ do
 
       spago ["init"] >>= shouldBeSuccess
       cp "../fixtures/spago-run-args.purs" "src/Main.purs"
       spago ["install", "node-process"] >>= shouldBeSuccess
       spago ["build"] >>= shouldBeSuccess
-      spago ["run", "--backend-args", "hello world", "--node-args", "mad world"] >>= shouldBeSuccessOutput "run-args-output.txt"
+      spago ["run", "--exec-args", "hello world", "--node-args", "hallo welt"] >>= shouldBeSuccessOutput "run-args-combined-output.txt"
 
   describe "spago bundle" $ do
 

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -652,7 +652,7 @@ spec = around_ setup $ do
 
       shell "psa --version" empty >>= \case
         ExitSuccess -> spago ["-v", "run"] >>= shouldBeSuccessOutput "run-output.txt"
-        ExitFailure _ ->  spago ["-v", "run"] >>= shouldBeSuccessOutput "run-output.txt" 
+        ExitFailure _ ->  spago ["-v", "run"] >>= shouldBeSuccessOutput "run-output.txt"
 
     it "Spago should be able to not use `psa`" $ do
 
@@ -667,6 +667,30 @@ spec = around_ setup $ do
       spago ["install", "node-buffer", "node-streams", "node-process"] >>= shouldBeSuccess
       spago ["build"] >>= shouldBeSuccess
       shellStrictWithErr "echo wut| spago run" empty >>= shouldBeSuccessOutput "spago-run-passthrough.txt"
+
+    it "Spago should use backend-args" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      cp "../fixtures/spago-run-args.purs" "src/Main.purs"
+      spago ["install", "node-process"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
+      spago ["run", "--backend-args", "hello world"] >>= shouldBeSuccessOutput "run-args-output.txt"
+
+    it "Spago should use node-args" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      cp "../fixtures/spago-run-args.purs" "src/Main.purs"
+      spago ["install", "node-process"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
+      spago ["run", "--node-args", "hello world"] >>= shouldBeSuccessOutput "run-args-output.txt"
+
+    it "Spago should prefer backend-args" $ do
+
+      spago ["init"] >>= shouldBeSuccess
+      cp "../fixtures/spago-run-args.purs" "src/Main.purs"
+      spago ["install", "node-process"] >>= shouldBeSuccess
+      spago ["build"] >>= shouldBeSuccess
+      spago ["run", "--backend-args", "hello world", "--node-args", "mad world"] >>= shouldBeSuccessOutput "run-args-output.txt"
 
   describe "spago bundle" $ do
 
@@ -689,7 +713,7 @@ spec = around_ setup $ do
       spago ["bundle-app", "--to", "bundle-app-src-map.js", "--source-maps"] >>= shouldBeSuccess
       checkFixture "bundle-app-src-map.js"
       checkFileExist "bundle-app-src-map.js.map"
-  
+
   describe "spago make-module" $ do
 
     it "Spago should fail but should point to the replacement command" $ do

--- a/test/fixtures/run-args-combined-output.txt
+++ b/test/fixtures/run-args-combined-output.txt
@@ -1,0 +1,1 @@
+["hello","world","hallo","welt"]

--- a/test/fixtures/run-args-output.txt
+++ b/test/fixtures/run-args-output.txt
@@ -1,0 +1,1 @@
+["hello","world"]

--- a/test/fixtures/spago-run-args.purs
+++ b/test/fixtures/spago-run-args.purs
@@ -1,0 +1,14 @@
+module Main where
+
+import Effect (Effect)
+import Effect.Console (log)
+import Node.Process (argv)
+import Prelude (Unit, ($), bind)
+import Data.Array (drop)
+import Data.Show (show)
+
+main :: Effect Unit
+main = do
+  args <- argv
+  -- dropping the first two args, node path and script name, to make test stable
+  log $ show $ drop 2 args


### PR DESCRIPTION
### Description of the change

This allows the more general "backend-args" to be used instead of "node-args", since there are now multiple backends and the flag is not actually specific to node. It addresses https://github.com/purescript/spago/issues/709. 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)
