### PR TITLE
fix missed code block closing statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ You can run a script via the following, optionally specifying a package set to u
 
 ```bash
 $ spago script --tag psc-13.8 -d node-fs path/to/script.purs
+```
 
 
 ### List available packages


### PR DESCRIPTION
In #712 I accidentally missed a code block closing statement in the README - this fixes it.