### PR TITLE
Reuse the same temp folder across many script runs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -93,6 +93,7 @@ library:
   - bytestring
   - Cabal
   - containers
+  - cryptonite
   - dhall >= 1.31.1
   - directory >= 1.3.4.0
   - either

--- a/spago.cabal
+++ b/spago.cabal
@@ -64,7 +64,7 @@ library
   hs-source-dirs:
       src
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable DerivingStrategies DoAndIfThenElse DuplicateRecordFields EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase LiberalTypeSynonyms MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings PartialTypeSignatures PatternGuards PolyKinds QuantifiedConstraints RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeSynonymInstances UndecidableInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances -optP-Wno-nonportable-include-path
   build-depends:
       Cabal
     , Glob
@@ -76,6 +76,7 @@ library
     , bower-json
     , bytestring
     , containers
+    , cryptonite
     , dhall >=1.31.1
     , directory >=1.3.4.0
     , either
@@ -127,7 +128,7 @@ executable spago
   hs-source-dirs:
       app
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable DerivingStrategies DoAndIfThenElse DuplicateRecordFields EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase LiberalTypeSynonyms MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings PartialTypeSignatures PatternGuards PolyKinds QuantifiedConstraints RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeSynonymInstances UndecidableInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances -optP-Wno-nonportable-include-path
   build-depends:
       base >=4.7 && <5
     , spago
@@ -157,7 +158,7 @@ test-suite spec
   hs-source-dirs:
       test
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable DerivingStrategies DoAndIfThenElse DuplicateRecordFields EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase LiberalTypeSynonyms MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings PartialTypeSignatures PatternGuards PolyKinds QuantifiedConstraints RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeSynonymInstances UndecidableInstances ViewPatterns
-  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances -threaded -rtsopts -with-rtsopts=-N -main-is Main
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N -main-is Main
   build-depends:
       QuickCheck
     , base >=4.7 && <5

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -80,7 +80,7 @@ newtype TargetPath = TargetPath { unTargetPath :: Text }
 newtype SourcePath = SourcePath { unSourcePath :: Text }
   deriving newtype (Show, Dhall.FromDhall)
 newtype PursArg = PursArg { unPursArg :: Text }
-  deriving newtype (Eq)
+  deriving newtype (Eq, Show)
 newtype BackendArg = BackendArg { unBackendArg :: Text }
   deriving newtype (Eq)
 
@@ -153,7 +153,7 @@ data ScriptBuildOptions = ScriptBuildOptions
   , beforeCommands :: [Text]
   , thenCommands   :: [Text]
   , elseCommands   :: [Text]
-  }
+  } deriving (Eq, Generic, Show)
 
 
 -- | Spago configuration file type


### PR DESCRIPTION
As per title, this is a followup on #712 to avoid reinstalling the same dependencies over and over when running scripts

cc @colinwahl @thomashoneyman for review