### PR TITLE
Update the suggestion for compiler version override to the new syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,6 @@ Example:
 let upstream = -- <package set URL here>
 in  upstream
   with foobar = ../foobar/spago.dhall as Location
-  }
 ```
 
 

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -188,9 +188,11 @@ pursVersionMismatch currentVersion minVersion = makeMessage
   , "There are a few ways to solve this:"
   , "- install a compatible `purs` version (i.e. in the same 'semver range' as the one in the package set)"
   , "- if the `purs` version is 'too new', you can try using `spago upgrade-set` to upgrade to the latest package set"
-  , "- if you know what you're doing and you want to disable this check, you can override the `version` of the `metadata` package in the packages.dhall:"
+  , "- if you know what you're doing and you want to disable this check, you can override the `version` of the `metadata` package in the packages.dhall, e.g.:"
   , ""
-  , "  let overrides = { metadata = upstream.metadata // { version = \"v" <> currentVersion <> "\" } }"
+  , "  let upstream = <package-set url here>"
+  , "  in  upstream"
+  , "    with metadata.version = \"v" <> currentVersion <> "\""
   , ""
   ]
 


### PR DESCRIPTION
Fix #734 