### PR TITLE
Fix finding psa on Windows (#693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Other improvements:
 - Bump `dhall` dependency from 1.37.1 to 1.38.0 (#739)
+- Fix `psa` not being found on Windows (#740, #693)
 
 ## [0.19.0] - 2021-01-02
 

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -3,7 +3,6 @@ module Spago.RunEnv where
 import Spago.Prelude
 import Spago.Env
 
-import qualified Data.Text as Text
 import qualified System.Environment  as Env
 import qualified Distribution.System as OS
 import qualified RIO
@@ -161,13 +160,7 @@ getPurs usePsa = do
     UsePsa -> findExecutable "psa" >>= \case
       Just _  -> pure "psa"
       Nothing -> pure "purs"
-  -- We first try this for Windows
-  PursCmd <$> case OS.buildOS of
-    OS.Windows -> do
-      findExecutable (pursCandidate <> ".cmd") >>= \case
-        Just _ -> pure (Text.pack pursCandidate <> ".cmd")
-        Nothing -> findExecutableOrDie pursCandidate
-    _ -> findExecutableOrDie pursCandidate
+  PursCmd <$> findExecutableOrDie pursCandidate
 
 getGit :: HasLogFunc env => RIO env GitCmd
 getGit = GitCmd <$> findExecutableOrDie "git"


### PR DESCRIPTION
In RunEnv.hs:getPurs we were just using the standard Directory.findExecutable to look for `psa`, forgetting to check for `psa.cmd` too. In windows this was looking for `psa.exe`, which doesn't exist.

To help prevent this happening again, a self-written `findExecutable` function in Prelude is added, instead of just exporting
`Directory.findExecutable`. This new version always first checks for a `.cmd` version of the given executable name on Windows.

Fix #693