### PR TITLE
Using jsdelivr.net as CDN to fetch cache metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Fetch global cache metadata file via CDN (_jsDelivr_)
+
 ## [0.19.1] - 2021-02-04
 
 Bugfixes:

--- a/src/Spago/GlobalCache.hs
+++ b/src/Spago/GlobalCache.hs
@@ -94,7 +94,7 @@ getMetadata = do
 
   logDebug $ "Global cache directory: " <> displayShow globalCacheDir
 
-  let metaURL = "https://raw.githubusercontent.com/spacchetti/package-sets-metadata/master/metadataV1.json"
+  let metaURL = "https://cdn.jsdelivr.net/gh/spacchetti/package-sets-metadata@master/metadataV1.json"
 
       globalPathToMeta = globalCacheDir </> "metadataV1.json"
 


### PR DESCRIPTION
### Description of the change

Leverage CDN distribution to boost up metadata fetching.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
