### PR TITLE
Use the correct path in errors about alternate config names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.1] - 2021-02-04
+## [0.19.1] - 2021-02-22
 
 Bugfixes:
 - Fix `psa` not being found on Windows (#740, #693)
+- Use the correct path when erroring out about alternate configurations missing (#746, #747)
 
 Other improvements:
 - Bump `dhall` dependency from 1.37.1 to 1.38.0 (#739)

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -154,7 +154,7 @@ ensureConfig = do
   ConfigPath path <- view (the @ConfigPath)
   exists <- testfile path
   if not exists
-    then pure $ Left $ display Messages.cannotFindConfig
+    then pure $ Left $ display $ Messages.cannotFindConfig path
     else try parseConfig >>= \case
       Right config -> do
         PackageSet.ensureFrozen $ Text.unpack path
@@ -390,7 +390,7 @@ withConfigAST transform = do
   ConfigPath path <- view (the @ConfigPath)
   rawConfig <- liftIO $ Dhall.readRawExpr path
   case rawConfig of
-    Nothing -> die [ display $ Messages.cannotFindConfig ]
+    Nothing -> die [ display $ Messages.cannotFindConfig path ]
     Just (header, expr) -> do
       newExpr <- transformMExpr transform expr
       -- Write the new expression only if it has actually changed

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -47,9 +47,9 @@ failedToParseRepoString repo = makeMessage
   , ""
   ]
 
-cannotFindConfig :: Text
-cannotFindConfig = makeMessage
-  [ "There's no " <> surroundQuote "spago.dhall" <> " in your current location."
+cannotFindConfig :: Text -> Text
+cannotFindConfig configPath = makeMessage
+  [ "There's no " <> surroundQuote configPath <> " in your current location."
   , ""
   , "If you already have a spago project you might be in the wrong subdirectory,"
   , "otherwise you might want to run `spago init` to initialize a new project."

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -192,6 +192,10 @@ spec = around_ setup $ do
       spago ["-x", "alternative1.dhall", "install", "simple-json"] >>= shouldBeSuccess
       checkFixture "alternative1.dhall"
 
+    it "Spago should fail when the alternate config file doesn't exist" $ do
+      spago ["init"] >>= shouldBeSuccess
+      spago ["install", "-x", "test.dhall"] >>= shouldBeFailureStderr "alternate-config-missing.txt"
+
     it "Spago should install successfully when the config file is in another directory" $ do
 
       spago ["init"] >>= shouldBeSuccess

--- a/test/fixtures/alternate-config-missing.txt
+++ b/test/fixtures/alternate-config-missing.txt
@@ -1,0 +1,5 @@
+[31m[error] [0mFailed to read the config. Error was:[0m
+[31m[error] [0mThere's no "test.dhall" in your current location.
+
+If you already have a spago project you might be in the wrong subdirectory,
+otherwise you might want to run `spago init` to initialize a new project.[0m


### PR DESCRIPTION
Fix #746 