### PR TITLE
Allow verify(-set) to work with alternate backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Allow `verify` and `verify-set` to work with alternate backends (when run in the context
+  of a `spago.dhall` with `backend` set)
+
 ## [0.19.1] - 2021-02-22
 
 Bugfixes:

--- a/src/Spago/Env.hs
+++ b/src/Spago/Env.hs
@@ -64,6 +64,7 @@ type HasEnv env =
   )
 
 type HasConfig env = ( HasType Config env, HasPackageSet env )
+type HasMaybeConfig env = ( HasType (Maybe Config) env, HasPackageSet env )
 
 type HasVerifyEnv env =
   ( HasLogFunc env
@@ -71,6 +72,7 @@ type HasVerifyEnv env =
   , HasGlobalCache env
   , HasPurs env
   , HasPackageSet env
+  , HasMaybeConfig env
   )
 
 type HasPublishEnv env =
@@ -108,6 +110,7 @@ data VerifyEnv = VerifyEnv
   , envGlobalCache :: !GlobalCache
   , envPursCmd :: !PursCmd
   , envPackageSet :: !PackageSet
+  , envConfig :: !(Maybe Config)
   } deriving (Generic)
 
 data InstallEnv = InstallEnv

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -96,6 +96,7 @@ withVerifyEnv usePsa app = do
   Env{..} <- getEnv
   envPursCmd <- getPurs usePsa
   envPackageSet <- getPackageSet
+  envConfig <- hush <$> Config.ensureConfig 
   runRIO VerifyEnv{..} app
 
 withPublishEnv


### PR DESCRIPTION
### Description of the change

Allow verify(-set) to work with alternate backends (when run in the context of a `spago.dhall` with `backend` set).

I've been using this change to verify the `purerl` package set

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
