### PR TITLE
Hack so bump-version doesn't fail if the packages doesn't exist in the bower registry

### DIFF
--- a/src/Spago/Bower.hs
+++ b/src/Spago/Bower.hs
@@ -100,7 +100,8 @@ mkBowerVersion
 mkBowerVersion packageName version (Repo repo) = do
   let args = ["info", "--json", Bower.runPackageName packageName <> "#" <> version]
   (code, out, _) <- runBower args
-
+  -- Here `bower info` likely fails because the package is not in the Bower registry.
+  -- So we just include the full repo for the package - see #682 for more info
   if (code /= ExitSuccess) then
     pure $ Bower.VersionRange $ repo <> "#" <> version
   else do


### PR DESCRIPTION
### Description of the change

This is the implementation of the proposal to how to handle packages which are not in the (closed) bower registry (#682).
With that fix `bump-version` at least works properly for me.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog

