### PR TITLE
Fix colors on Windows (#749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Breaking changes (😱!!!):
 
 Bugfixes:
 - Properly call `psa` to avoid warnings (#730)
+- Color output now works on Windows (#749)
 
 Other improvements:
 - `spago build` now detects and warns about unused dependencies (#730, #598)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Color output now works correctly or is disabled on Windows (#768, #749)
+
+Other improvements:
+- Color output is now automatically disabled when output is redirected to a file.
+  Also respects a [`NO_COLOR`](https://no-color.org/) environment variable (#768)
+
 ## [0.20.0] - 2021-04-07
 
 Breaking changes (😱!!!):
@@ -14,7 +21,6 @@ Breaking changes (😱!!!):
 
 Bugfixes:
 - Properly call `psa` to avoid warnings (#730)
-- Color output now works on Windows (#749)
 
 Other improvements:
 - `spago build` now detects and warns about unused dependencies (#730, #598)

--- a/spago.cabal
+++ b/spago.cabal
@@ -139,7 +139,8 @@ executable spago
   default-extensions: ApplicativeDo BangPatterns BinaryLiterals ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable DerivingStrategies DoAndIfThenElse DuplicateRecordFields EmptyDataDecls ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase LiberalTypeSynonyms MonadFailDesugaring MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings PartialTypeSignatures PatternGuards PolyKinds QuantifiedConstraints RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeSynonymInstances UndecidableInstances ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -fprint-potential-instances -optP-Wno-nonportable-include-path
   build-depends:
-      base >=4.7 && <5
+      ansi-terminal
+    , base >=4.7 && <5
     , spago
     , text <1.3
     , turtle

--- a/test/fixtures/alternate-config-missing.txt
+++ b/test/fixtures/alternate-config-missing.txt
@@ -1,5 +1,5 @@
-[31m[error] [0mFailed to read the config. Error was:[0m
-[31m[error] [0mThere's no "test.dhall" in your current location.
+[error] Failed to read the config. Error was:
+[error] There's no "test.dhall" in your current location.
 
 If you already have a spago project you might be in the wrong subdirectory,
-otherwise you might want to run `spago init` to initialize a new project.[0m
+otherwise you might want to run `spago init` to initialize a new project.

--- a/test/fixtures/alternative2install-stderr.txt
+++ b/test/fixtures/alternative2install-stderr.txt
@@ -1,2 +1,2 @@
-[33m[warn] [0mFailed to add dependencies. You should have a record with the `dependencies` key for this to work.[0m
-[33m[warn] [0mConfiguration file was not updated.[0m
+[warn] Failed to add dependencies. You should have a record with the `dependencies` key for this to work.
+[warn] Configuration file was not updated.

--- a/test/fixtures/bundle-stderr.txt
+++ b/test/fixtures/bundle-stderr.txt
@@ -1,1 +1,1 @@
-[31m[error] [0mThe `bundle` command has been replaced with `bundle-app`, so use that instead.[0m
+[error] The `bundle` command has been replaced with `bundle-app`, so use that instead.

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -1,8 +1,8 @@
 purs compile: No files found using pattern: test/**/*.purs
-[34m[info] [0mBuild succeeded.[0m
-[33m[warn] [0mNone of your project files import modules from some projects that are in the direct dependencies of your project.
+[info] Build succeeded.
+[warn] None of your project files import modules from some projects that are in the direct dependencies of your project.
 These dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:
-- effect[0m
-[31m[error] [0mSome of your project files import modules from packages that are not in the direct dependencies of your project.
+- effect
+[error] Some of your project files import modules from packages that are not in the direct dependencies of your project.
 To fix this error add the following packages to the list of dependencies in your config:
-- prelude[0m
+- prelude

--- a/test/fixtures/check-unused-dependency.txt
+++ b/test/fixtures/check-unused-dependency.txt
@@ -1,5 +1,5 @@
 purs compile: No files found using pattern: test/**/*.purs
-[34m[info] [0mBuild succeeded.[0m
-[33m[warn] [0mNone of your project files import modules from some projects that are in the direct dependencies of your project.
+[info] Build succeeded.
+[warn] None of your project files import modules from some projects that are in the direct dependencies of your project.
 These dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:
-- effect[0m
+- effect

--- a/test/fixtures/circular-dependencies.txt
+++ b/test/fixtures/circular-dependencies.txt
@@ -1,3 +1,3 @@
-[31m[error] [0mThe following packages have circular dependencies:[0m
-[31m[error] [0m  - a[0m
-[31m[error] [0m  - b[0m
+[error] The following packages have circular dependencies:
+[error]   - a
+[error]   - b

--- a/test/fixtures/make-module-stderr.txt
+++ b/test/fixtures/make-module-stderr.txt
@@ -1,1 +1,1 @@
-[31m[error] [0mThe `make-module` command has been replaced with `bundle-module`, so use that instead.[0m
+[error] The `make-module` command has been replaced with `bundle-module`, so use that instead.

--- a/test/fixtures/missing-dependencies.txt
+++ b/test/fixtures/missing-dependencies.txt
@@ -1,3 +1,3 @@
-[31m[error] [0mThe following packages do not exist in your package set:[0m
-[31m[error] [0m  - bar[0m
-[31m[error] [0m  - foo[0m
+[error] The following packages do not exist in your package set:
+[error]   - bar
+[error]   - foo

--- a/test/fixtures/spago-install-existing-dep-stderr.txt
+++ b/test/fixtures/spago-install-existing-dep-stderr.txt
@@ -1,1 +1,1 @@
-[33m[warn] [0mConfiguration file was not updated.[0m
+[warn] Configuration file was not updated.

--- a/test/fixtures/spago-install-purescript-prefix-stderr.txt
+++ b/test/fixtures/spago-install-purescript-prefix-stderr.txt
@@ -1,6 +1,6 @@
-[34m[info] [0mThe package 'purescript-newtype' was resolved to the 'newtype' package[0m
-[34m[info] [0mInstalling 1 dependencies.[0m
-[34m[info] [0mSearching for packages cache metadata..[0m
-[34m[info] [0mRecent packages cache metadata found, using it..[0m
-[34m[info] [0mInstalling "newtype"[0m
-[34m[info] [0mInstallation complete.[0m
+[info] The package 'purescript-newtype' was resolved to the 'newtype' package
+[info] Installing 1 dependencies.
+[info] Searching for packages cache metadata..
+[info] Recent packages cache metadata found, using it..
+[info] Installing "newtype"
+[info] Installation complete.

--- a/test/fixtures/spago-test-not-found.txt
+++ b/test/fixtures/spago-test-not-found.txt
@@ -1,1 +1,1 @@
-[31m[error] [0mModule 'Test.Main' not found! Are you including it in your build?[0m
+[error] Module 'Test.Main' not found! Are you including it in your build?

--- a/test/fixtures/test-output-stderr.txt
+++ b/test/fixtures/test-output-stderr.txt
@@ -1,2 +1,2 @@
-[34m[info] [0mBuild succeeded.[0m
-[34m[info] [0mTests succeeded.[0m
+[info] Build succeeded.
+[info] Tests succeeded.

--- a/test/fixtures/verify-set-failure-no-files.txt
+++ b/test/fixtures/verify-set-failure-no-files.txt
@@ -1,6 +1,6 @@
-[31m[error] [0mCould not find a valid "spago.dhall" or "packages.dhall"[0m
-[31m[error] [0mError was:[0m
-[31m[error] [0mThere's no "spago.dhall" in your current location.
+[error] Could not find a valid "spago.dhall" or "packages.dhall"
+[error] Error was:
+[error] There's no "spago.dhall" in your current location.
 
 If you already have a spago project you might be in the wrong subdirectory,
-otherwise you might want to run `spago init` to initialize a new project.[0m
+otherwise you might want to run `spago init` to initialize a new project.

--- a/test/fixtures/verify-set-success.txt
+++ b/test/fixtures/verify-set-success.txt
@@ -1,1 +1,1 @@
-[31m[error] [0mCould not find a valid "spago.dhall" or "packages.dhall"[0m
+[error] Could not find a valid "spago.dhall" or "packages.dhall"


### PR DESCRIPTION
Looking through the Stack source code lead me to the [`hSupportsANSIWithoutEmulation`](https://hackage.haskell.org/package/ansi-terminal-0.11/docs/System-Console-ANSI.html#v:hSupportsANSIWithoutEmulation) function. Calling this on Windows 10+ returns `Just True` but also enables the processing of the Ansi control codes as a side effect.

This change also has the added benefit that (on Windows), the ANSI codes aren't present when output is redirected to a text file.

Code is just proof-of concept; feel free to modify as you wish. Haven't tested on *nix but it's working on Windows for me.

