### PR TITLE
Print install command to fix missing transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Print `spago install` command to fix missing transitive dependencies
+
 ## [0.20.0] - 2021-04-07
 
 Breaking changes (😱!!!):

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -242,3 +242,5 @@ sourceImportsTransitiveDependency transitive = makeMessage $
   [ "Some of your project files import modules from packages that are not in the direct dependencies of your project."
   , "To fix this error add the following packages to the list of dependencies in your config:"
   ] <> map (\package -> "- " <> package) transitive
+  <> [ "You may install those packages by running the following command:"
+  , "spago install " <> Text.intercalate " " transitive ]

--- a/src/Spago/Messages.hs
+++ b/src/Spago/Messages.hs
@@ -242,5 +242,5 @@ sourceImportsTransitiveDependency transitive = makeMessage $
   [ "Some of your project files import modules from packages that are not in the direct dependencies of your project."
   , "To fix this error add the following packages to the list of dependencies in your config:"
   ] <> map (\package -> "- " <> package) transitive
-  <> [ "You may install those packages by running the following command:"
+  <> [ "You may add these dependencies by running the following command:"
   , "spago install " <> Text.intercalate " " transitive ]

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -425,7 +425,7 @@ spec = around_ setup $ do
       it "Spago should fail on direct project imports from transitive dependencies" $ do
         spago ["init"] >>= shouldBeSuccess
         rm "spago.dhall"
-        writeTextFile "spago.dhall" $ "{ name = \"check-imports\", dependencies = [\"lists\"], packages = ./packages.dhall }"
+        writeTextFile "spago.dhall" $ "{ name = \"check-imports\", dependencies = [\"effect\", \"lists\"], packages = ./packages.dhall }"
         rm "src/Main.purs"
         writeTextFile "src/Main.purs" "module Main where\nimport Prelude\nimport Data.Maybe\nimport Data.List\nmain = unit"
         rm "test/Main.purs"

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -425,9 +425,9 @@ spec = around_ setup $ do
       it "Spago should fail on direct project imports from transitive dependencies" $ do
         spago ["init"] >>= shouldBeSuccess
         rm "spago.dhall"
-        writeTextFile "spago.dhall" $ "{ name = \"check-imports\", dependencies = [\"effect\"], packages = ./packages.dhall }"
+        writeTextFile "spago.dhall" $ "{ name = \"check-imports\", dependencies = [\"lists\"], packages = ./packages.dhall }"
         rm "src/Main.purs"
-        writeTextFile "src/Main.purs" "module Main where\nimport Prelude\nmain = unit"
+        writeTextFile "src/Main.purs" "module Main where\nimport Prelude\nimport Data.Maybe\nimport Data.List\nmain = unit"
         rm "test/Main.purs"
         spago ["build"]
         spago ["build"] >>= shouldBeFailureStderr "check-direct-import-transitive-dependency.txt"

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -5,4 +5,6 @@ These dependencies are unused. To fix this warning, remove the following package
 - effect[0m
 [31m[error] [0mSome of your project files import modules from packages that are not in the direct dependencies of your project.
 To fix this error add the following packages to the list of dependencies in your config:
-- prelude[0m
+- prelude
+You may install those packages by running the following command:
+spago install prelude[0m

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -8,4 +8,4 @@ To fix this error add the following packages to the list of dependencies in your
 - maybe
 - prelude
 You may add these dependencies by running the following command:
-spago install maybe prelude[0m
+spago install maybe prelude

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -6,5 +6,5 @@ These dependencies are unused. To fix this warning, remove the following package
 [31m[error] [0mSome of your project files import modules from packages that are not in the direct dependencies of your project.
 To fix this error add the following packages to the list of dependencies in your config:
 - prelude
-You may install those packages by running the following command:
+You may add these dependencies by running the following command:
 spago install prelude[0m

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -1,10 +1,8 @@
 purs compile: No files found using pattern: test/**/*.purs
 [34m[info] [0mBuild succeeded.[0m
-[33m[warn] [0mNone of your project files import modules from some projects that are in the direct dependencies of your project.
-These dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:
-- effect[0m
 [31m[error] [0mSome of your project files import modules from packages that are not in the direct dependencies of your project.
 To fix this error add the following packages to the list of dependencies in your config:
+- maybe
 - prelude
 You may add these dependencies by running the following command:
-spago install prelude[0m
+spago install maybe prelude[0m

--- a/test/fixtures/check-direct-import-transitive-dependency.txt
+++ b/test/fixtures/check-direct-import-transitive-dependency.txt
@@ -1,5 +1,8 @@
 purs compile: No files found using pattern: test/**/*.purs
 [34m[info] [0mBuild succeeded.[0m
+[33m[warn] [0mNone of your project files import modules from some projects that are in the direct dependencies of your project.
+These dependencies are unused. To fix this warning, remove the following packages from the list of dependencies in your config:
+- effect[0m
 [31m[error] [0mSome of your project files import modules from packages that are not in the direct dependencies of your project.
 To fix this error add the following packages to the list of dependencies in your config:
 - maybe


### PR DESCRIPTION
### Description of the change

Prints a `spago install` command that will likely install missing transitive dependencies.
See #769 for context.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [x] **NA** - Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)
  - Not extensive