### PR TITLE
Note purescript-psa testing incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Docs: note `purescript-psa` testing incompatibility
+
 ## [0.20.0] - 2021-04-07
 
 Breaking changes (😱!!!):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ $ stack test
 $ stack test --test-arguments='--match "/Spago/spago run/Spago should use exec-args"'
 ```
 
+Note that you may need to uninstall [`purescript-psa`](https://github.com/natefaubion/purescript-psa) for tests to pass.
 
 ## Merging changes
 


### PR DESCRIPTION
### Description of the change

I noticed I needed to uninstall `purescript-psa` for tests to pass. Don't know if there's another way to get this to work.

https://github.com/purescript/spago/pull/730#issuecomment-812027464 seems related.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
