### PR TITLE
Update docs-search to the latest version, simplify including it in the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,9 @@ jobs:
         shell: bash
 
       - name: Build
-        run: stack build --pedantic
+        run: |
+          make
+          stack build --pedantic
         shell: bash
 
       - name: Install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
+          make
           stack install --dependencies-only
           mkdir artifacts
           stack build --copy-bins --local-bin-path ./artifacts
@@ -75,6 +76,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
+          make
           stack install --dependencies-only
           stack build --copy-bins --local-bin-path ./artifacts
           cp artifacts/spago.exe spago.exe

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ test/spago-test
 .stack-work/
 *~
 **/__pycache__
-templates/docs-search-app.js
-templates/purescript-docs-search
+templates/docs-search-app*
+templates/purescript-docs-search*
 .envrc
 curator.log
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ If you'd like to develop spago locally, the recommended tool to use is [stack][s
 To compile the project from source you can do
 
 ```bash
+$ make
 $ stack build --fast
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 all: fetch-templates
 
 fetch-templates:
-	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/docs-search-app.js -O templates/docs-search-app-0.0.10.js
-	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/purescript-docs-search -O templates/purescript-docs-search-0.0.10
+	@curl https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/docs-search-app.js -o templates/docs-search-app-0.0.10.js
+	@curl https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/purescript-docs-search -o templates/purescript-docs-search-0.0.10
 	@chmod +x templates/purescript-docs-search-0.0.10
-	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/docs-search-app.js -O templates/docs-search-app-0.0.11.js
-	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/purescript-docs-search -O templates/purescript-docs-search-0.0.11
+	@curl https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/docs-search-app.js -o templates/docs-search-app-0.0.11.js
+	@curl https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/purescript-docs-search -o templates/purescript-docs-search-0.0.11
 	@chmod +x templates/purescript-docs-search-0.0.11
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all: fetch-templates
+
+fetch-templates:
+	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/docs-search-app.js -O templates/docs-search-app-0.0.10.js
+	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.10/purescript-docs-search -O templates/purescript-docs-search-0.0.10
+	@chmod +x templates/purescript-docs-search-0.0.10
+	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/docs-search-app.js -O templates/docs-search-app-0.0.11.js
+	@wget https://github.com/purescript/purescript-docs-search/releases/download/v0.0.11/purescript-docs-search -O templates/purescript-docs-search-0.0.11
+	@chmod +x templates/purescript-docs-search-0.0.11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
   - chmod a+x purescript
 
 build_script:
+  - make
   - stack build
   - stack install --local-bin-path bin
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ cache:
   - '.stack-work -> %STACK_YAML%, appveyor.yml'
 
 install:
+  - choco install -y make
   # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
   - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
   - curl --silent --show-error --output stack.zip --location "https://github.com/commercialhaskell/stack/releases/download/v%STACK_VERSION%/stack-%STACK_VERSION%-windows-x86_64.zip"

--- a/spago.cabal
+++ b/spago.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 77b5d785b2feb191ce5732a72494d5d950758a3c9dd77a3c98827bf19c3bafa3
+-- hash: 64b3d7194bb34705b51fef4eaafd1841f1900b6826a9cda155ba8d6572b9bd46
 
 name:           spago
 version:        0.20.0
@@ -21,10 +21,12 @@ extra-source-files:
     README.md
     CHANGELOG.md
     templates/bower.json
-    templates/docs-search-app.js
+    templates/docs-search-app-0.0.10.js
+    templates/docs-search-app-0.0.11.js
     templates/gitignore
     templates/packages.dhall
-    templates/purescript-docs-search
+    templates/purescript-docs-search-0.0.10
+    templates/purescript-docs-search-0.0.11
     templates/purs-repl
     templates/spago.dhall
     templates/srcMain.purs

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -12,6 +12,7 @@ module Spago.Prelude
   , headMay
   , lastMay
   , empty
+  , ifM
 
   -- * Logging, errors, printing, etc
   , Pretty
@@ -70,7 +71,6 @@ module Spago.Prelude
   , repr
   , with
   , appendonly
-  , docsSearchVersion
   , githubTokenEnvVar
   ) where
 
@@ -141,6 +141,9 @@ die :: (MonadIO m, HasLogFunc env, MonadReader env m) => [Utf8Builder] -> m a
 die reasons = do
   traverse_ logError reasons
   exitFailure
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM p x y = p >>= \b -> if b then x else y
 
 -- | Suppress the 'Left' value of an 'Either'
 hush :: Either a b -> Maybe b
@@ -216,11 +219,6 @@ assertDirectory directory = do
       Directory.createDirectory directory
 
       Directory.setPermissions directory private
-
-
--- | Release tag for the `purescript-docs-search` app.
-docsSearchVersion :: Text
-docsSearchVersion = "v0.0.10"
 
 
 githubTokenEnvVar :: IsString t => t

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -5,6 +5,7 @@ module Spago.Purs
   , bundle
   , docs
   , pursVersion
+  , hasMinPursVersion
   , parseDocsFormat
   , findFlag
   , DocsFormat(..)
@@ -144,6 +145,13 @@ pursVersion = Turtle.Bytes.shellStrictWithErr (purs <> " --version") empty >>= \
   where
     purs = "purs"
 
+hasMinPursVersion :: (HasLogFunc env, HasPurs env) => Text -> RIO env Bool
+hasMinPursVersion maybeMinVersion = do
+  PursCmd { compilerVersion } <- view (the @PursCmd)
+  minVersion <- case Version.semver maybeMinVersion of
+    Left _ -> die [ "Unable to parse min version: " <> displayShow maybeMinVersion ]
+    Right minVersion -> pure minVersion
+  pure $ compilerVersion >= minVersion
 
 runWithOutput :: HasLogFunc env => Text -> Text -> Text -> RIO env ()
 runWithOutput command success failure = do

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -6,7 +6,6 @@ import Spago.Env
 import           System.Console.ANSI (hSupportsANSIWithoutEmulation)
 import qualified System.Environment  as Env
 import qualified Distribution.System as OS
-import qualified Data.Versions       as Version
 import qualified RIO
 import qualified Turtle
 
@@ -208,11 +207,8 @@ getMaybeGraph :: HasPursEnv env => BuildOptions -> Config -> [(PackageName, Pack
 getMaybeGraph BuildOptions{ depsOnly, sourcePaths } Config{ configSourcePaths } deps = do
   let partitionedGlobs@(Packages.Globs{..}) = Packages.getGlobs deps depsOnly configSourcePaths
       globs = Packages.getGlobsSourcePaths partitionedGlobs <> sourcePaths
-  PursCmd { compilerVersion } <- view (the @PursCmd)
-  minVersion <- case Version.semver "0.14.0" of
-    Left _ -> die [ "Unable to parse min version for imports check" ]
-    Right minVersion -> pure minVersion
-  if compilerVersion < minVersion
+  supportsGraph <- Purs.hasMinPursVersion "0.14.0"
+  if not supportsGraph
   then pure Nothing
   else do
     maybeGraph <- Purs.graph globs

--- a/src/Spago/TH.hs
+++ b/src/Spago/TH.hs
@@ -2,20 +2,13 @@
 
 module Spago.TH
   ( embedFileUtf8
-  , embedURLWithFallback
   ) where
 
 import           Prelude
 
-import           Control.Exception           (try, SomeException)
-import           Data.ByteString             (ByteString)
 import           Data.FileEmbed
-import           Data.Text                   (unpack)
 import           Data.Text.Encoding          as LT
-import           Language.Haskell.TH.Syntax  (Exp(..), Q, runIO, Lit(StringL))
-import           Network.HTTP.Client.Conduit (parseUrlThrow)
-import           Network.HTTP.Simple         (httpBS, getResponseBody)
-import qualified Data.ByteString             as BS
+import           Language.Haskell.TH.Syntax  (Exp(..), Q)
 
 -- | This is here so that we can embed files as Utf8 Text.
 --   The reason for that is that since we have unicode Dhall files,
@@ -28,23 +21,3 @@ import qualified Data.ByteString             as BS
 embedFileUtf8 :: FilePath -> Q Exp
 embedFileUtf8 filePath =
   [| LT.decodeUtf8 $(makeRelativeToProject filePath >>= embedFile) |]
-
--- | Embed a file from a URL or use a local file as a fallback.
---   If fetching the URL was successfull, write the contents to the fallback file.
-embedURLWithFallback
-  :: String
-  -- ^ A URL.
-  -> FilePath
-  -- ^ A fallback file.
-  -> Q Exp
-embedURLWithFallback url filePath = do
-
-  eiResponseBody <- runIO $ try $ do
-    req <- parseUrlThrow url
-    getResponseBody <$> httpBS req
-
-  case eiResponseBody :: Either SomeException ByteString of
-    Left _ -> embedFileUtf8 filePath
-    Right responseBody -> do
-      runIO $ BS.writeFile filePath responseBody
-      return . LitE . StringL . unpack $ LT.decodeUtf8 responseBody

--- a/src/Spago/Templates.hs
+++ b/src/Spago/Templates.hs
@@ -3,9 +3,7 @@ module Spago.Templates where
 
 import qualified Data.Text                as T
 
-import           Spago.TH                 (embedFileUtf8, embedURLWithFallback)
-import           Spago.Prelude
-
+import           Spago.TH                 (embedFileUtf8)
 
 packagesDhall :: T.Text
 packagesDhall = $(embedFileUtf8 "templates/packages.dhall")
@@ -28,20 +26,14 @@ bowerJson = $(embedFileUtf8 "templates/bower.json")
 pursRepl :: T.Text
 pursRepl = $(embedFileUtf8 "templates/purs-repl")
 
-docsSearchApp :: T.Text
-docsSearchApp =
-  $(embedURLWithFallback
-    ( "https://github.com/spacchetti/purescript-docs-search/releases/download/"
-   <> T.unpack docsSearchVersion
-   <> "/docs-search-app.js"
-    )
-    "templates/docs-search-app.js")
+docsSearchApp0010 :: T.Text
+docsSearchApp0010 = $(embedFileUtf8 "templates/docs-search-app-0.0.10.js")
 
-docsSearch :: T.Text
-docsSearch =
-  $(embedURLWithFallback
-     ( "https://github.com/spacchetti/purescript-docs-search/releases/download/"
-    <> T.unpack docsSearchVersion
-    <> "/purescript-docs-search"
-     )
-     "templates/purescript-docs-search")
+docsSearch0010 :: T.Text
+docsSearch0010 = $(embedFileUtf8 "templates/purescript-docs-search-0.0.10")
+
+docsSearchApp0011 :: T.Text
+docsSearchApp0011 = $(embedFileUtf8 "templates/docs-search-app-0.0.11.js")
+
+docsSearch0011 :: T.Text
+docsSearch0011 = $(embedFileUtf8 "templates/purescript-docs-search-0.0.11")


### PR DESCRIPTION
This PR:
- prepares for including `0.0.11` of `docs-search`
- removes the Template Haskell logic that makes it hard to understand which version is being included in the build, see https://github.com/purescript/purescript-docs-search/pull/46#issuecomment-820230672
- conditionally includes the right version of `docs-search` depending on the compiler version