### PR TITLE
Remove npm install from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,5 +113,4 @@ jobs:
           cp ../README.md ./README.md
           cp ../CONTRIBUTING.md ./CONTRIBUTING.md
           cp ../LICENSE ./LICENSE
-          npm install
           npm publish --non-interactive --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Remove npm install from release.yml to prevent overwriting the spago file 
+  with the Linux binary (#783)
+
 ## [0.20.1] - 2021-04-20
 
 Bugfixes:


### PR DESCRIPTION
### Description of the change

Remove `npm install` from the release GitHub Action workflow to prevent the Linux binary from overwriting the `spago` file. The `npm postinstall`  would download the newly created Linux binary and overwrite the `spago` file that was needed for Windows users.

closes #783 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
