### PR TITLE
Use spago.cabal to get version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Use spago.cabal instead of package.yaml to get version number (#787)
+
 ## [0.20.1] - 2021-04-20
 
 Bugfixes:

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-grep "version:" package.yaml | sed "s/version: *//g"
+grep "^version:" spago.cabal | sed "s/version: *//g"


### PR DESCRIPTION
### Description of the change

Use `spago.cabal` in the `get-version` script. Previously `package.yaml` was used; however, that file was removed.

closes #787 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
