### PR TITLE
Don't warn on unused deps when building --deps-only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 Bugfixes:
+- Don't warn on unused deps when building --deps-only. (#794)
+
+## [0.20.3] - 2021-05-12
+
+Bugfixes:
 - Fix `docs` command error due to bad templates (#792)
 
 ## [0.20.2] - 2021-05-06

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -117,7 +117,7 @@ build maybePostBuild = do
                     $ Set.toList
                     $ Set.difference importedPackages dependencyPackages
 
-              unless (null unusedPackages) $ do
+              unless (null unusedPackages || depsOnly == DepsOnly) $ do
                 logWarn $ display $ Messages.unusedDependency unusedPackages
 
               unless (null transitivePackages) $ do

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -114,6 +114,7 @@ data PathType
 
 -- | Only build deps and ignore project paths
 data DepsOnly = DepsOnly | AllSources
+  deriving (Eq)
 
 data Watch = Watch | BuildOnce
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,3 +15,6 @@ flags:
   haskeline:
     terminfo: false
     examples: false
+  cryptonite:
+    use_target_attributes: false
+

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -442,6 +442,16 @@ spec = around_ setup $ do
         spago ["build"]
         spago ["--no-psa", "build"] >>= shouldBeSuccessStderr "check-unused-dependency.txt"
 
+      it "Spago should not warn on unused dependencies when building deps-only" $ do
+        spago ["init"] >>= shouldBeSuccess
+        rm "spago.dhall"
+        writeTextFile "spago.dhall" $ "{ name = \"check-imports\", dependencies = [\"effect\", \"prelude\"], packages = ./packages.dhall }"
+        rm "src/Main.purs"
+        writeTextFile "src/Main.purs" "module Main where\nimport Prelude\nmain :: Unit\nmain = unit"
+        rm "test/Main.purs"
+        spago ["build"]
+        spago ["--no-psa", "build", "--deps-only"] >>= shouldBeSuccessStderr "spago-build-succeeded-stderr.txt"
+
     describe "alternate backend" $ do
 
       it "Spago should use alternate backend if option is specified" $ do

--- a/test/fixtures/spago-build-succeeded-stderr.txt
+++ b/test/fixtures/spago-build-succeeded-stderr.txt
@@ -1,0 +1,1 @@
+[info] Build succeeded.


### PR DESCRIPTION
### Description of the change

Don't warn on unused deps when building --deps-only. Fix #794

Also moved previously released item down changelist.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
