### PR TITLE
Add compatibility with versions-5.0.0.

### DIFF
--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -70,9 +70,9 @@ getCurrentVersion = do
 getNextVersion :: VersionBump -> SemVer -> Either Text SemVer
 getNextVersion spec currentV@SemVer{..} =
   case spec of
-    Major -> Right $ SemVer (_svMajor + 1) 0 0 [] []
-    Minor -> Right $ SemVer _svMajor (_svMinor + 1) 0 [] []
-    Patch -> Right $ SemVer _svMajor _svMinor (_svPatch + 1) [] []
+    Major -> Right $ SemVer (_svMajor + 1) 0 0 [] mempty
+    Minor -> Right $ SemVer _svMajor (_svMinor + 1) 0 [] mempty
+    Patch -> Right $ SemVer _svMajor _svMinor (_svPatch + 1) [] mempty
     Exact newV
       | currentV < newV -> Right newV
       | otherwise -> do


### PR DESCRIPTION
Spago is currently on LTS-17, which uses [`versions-4.0.3`](https://hackage.haskell.org/package/versions-4.0.3). LTS-18 includes [`versions-5.0.0`](https://www.stackage.org/haddock/lts-18.0/versions-5.0.0), which [updates the `SemVer` constructor](https://hackage.haskell.org/package/versions-5.0.0/changelog).

versions-4.0.3:

```haskell
data SemVer = SemVer
  { _svMajor  :: !Word
  , _svMinor  :: !Word
  , _svPatch  :: !Word
  , _svPreRel :: ![VChunk]
  , _svMeta   :: ![VChunk]
  }
```

versions-5.0.0:

```haskell
data SemVer = SemVer
  { _svMajor  :: !Word
  , _svMinor  :: !Word
  , _svPatch  :: !Word
  , _svPreRel :: ![VChunk]
  , _svMeta   :: !(Maybe Text)
  }
```

You can see that `_svMeta` goes from `[VChunk]` to `Maybe Text`.

This commit replaces `[]` with `mempty`, which works for both
`[VChunk]` and `Maybe Text`.

This gives us compatibility with both versions of `versions`.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
