### PR TITLE
Update Discord link to remove explicit invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,5 +113,5 @@ Learn by doing and get your hands dirty!
 
 [f-f]: https://github.com/f-f
 [stack]: http://haskellstack.org/
-[discord]: https://discord.gg/sMqwYUbvz6
+[discord]: https://purescript.org/chat
 [spago-issues]: https://github.com/purescript/spago/issues


### PR DESCRIPTION
### Description of the change

After some discussion with the infrastructure team, we've decided to implement a redirect from `purescript.org/chat` to the Discord invite link, so that resources that provide a link to the Discord don't have to update if anything were to happen with that particular invite link (for example, it is accidentally deactivated, or the channel moves, or the server owner leaves).

Related:
https://github.com/purescript/purescript/pull/4170