### PR TITLE
Always include psci-support when running `spago repl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Features:
+- Drop need for `psci-support` to be defined in `dependencies` field (#817)
+
 Bugfixes:
 - Don't warn on unused deps when building --deps-only. (#794)
 

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -53,8 +53,8 @@ main = withUtf8 $ do
         -> CLI.echo spagoVersion
       Path whichPath buildOptions
         -> Path.showPaths buildOptions whichPath
-      Repl replPackageNames paths pursArgs depsOnly
-        -> Spago.Build.repl replPackageNames paths pursArgs depsOnly
+      Repl replPackageNames paths pursArgs depsOnly replPackage
+        -> Spago.Build.repl replPackageNames paths pursArgs depsOnly replPackage
       BundleApp modName tPath shouldBuild buildOptions
         -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions globalUsePsa
       BundleModule modName tPath shouldBuild buildOptions

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -197,8 +197,9 @@ repl
   -> [SourcePath]
   -> [PursArg]
   -> Packages.DepsOnly
+  -> PackageName
   -> RIO env ()
-repl newPackages sourcePaths pursArgs depsOnly = do
+repl newPackages sourcePaths pursArgs depsOnly replPackage = do
   logDebug "Running `spago repl`"
   purs <- Run.getPurs NoPsa
   Config.ensureConfig >>= \case
@@ -218,12 +219,10 @@ repl newPackages sourcePaths pursArgs depsOnly = do
 
         Run.withInstallEnv' (Just (ensurePsciSupportIncluded config)) (replAction purs)
   where
-    packagePsciSupport = PackageName "psci-support"
-
     ensurePsciSupportIncluded :: Config -> Config
     ensurePsciSupportIncluded originalConfig@Config{dependencies = originalDeps}
-      | packagePsciSupport `elem` originalDeps = originalConfig
-      | otherwise = originalConfig { dependencies = Set.insert packagePsciSupport originalDeps }
+      | replPackage `elem` originalDeps = originalConfig
+      | otherwise = originalConfig { dependencies = Set.insert replPackage originalDeps }
 
     replAction purs = do
       Config{..} <- view (the @Config)

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -93,9 +93,6 @@ build maybePostBuild = do
                     $ find (\(_, sourcePath) -> matchesGlob (Text.unpack path) sourcePath)
                     $ Map.toList depsGlobs
 
-                defaultPackages :: Set PackageName
-                defaultPackages = Set.singleton (PackageName "psci-support")
-
                 importedPackages :: Set PackageName
                 importedPackages =
                   Set.fromList
@@ -109,8 +106,7 @@ build maybePostBuild = do
                 unusedPackages =
                   fmap packageName
                     $ Set.toList
-                    $ Set.difference dependencyPackages
-                    $ Set.union defaultPackages importedPackages
+                    $ Set.difference dependencyPackages importedPackages
 
                 transitivePackages =
                   fmap packageName
@@ -206,7 +202,7 @@ repl newPackages sourcePaths pursArgs depsOnly = do
   logDebug "Running `spago repl`"
   purs <- Run.getPurs NoPsa
   Config.ensureConfig >>= \case
-    Right config -> Run.withInstallEnv' (Just config) (replAction purs)
+    Right config -> Run.withInstallEnv' (Just (ensurePsciSupportIncluded config)) (replAction purs)
     Left err -> do
       logDebug err
       GlobalCache cacheDir _ <- view (the @GlobalCache)
@@ -215,22 +211,23 @@ repl newPackages sourcePaths pursArgs depsOnly = do
 
         writeTextFile ".purs-repl" Templates.pursRepl
 
-        let dependencies = [ PackageName "effect", PackageName "console", PackageName "psci-support" ] <> newPackages
+        let dependencies = [ PackageName "effect", PackageName "console" ] <> newPackages
 
         config <- Run.withPursEnv NoPsa $ do
           Config.makeTempConfig dependencies Nothing [] Nothing
 
-        Run.withInstallEnv' (Just config) (replAction purs)
+        Run.withInstallEnv' (Just (ensurePsciSupportIncluded config)) (replAction purs)
   where
+    packagePsciSupport = PackageName "psci-support"
+
+    ensurePsciSupportIncluded :: Config -> Config
+    ensurePsciSupportIncluded originalConfig@Config{dependencies = originalDeps}
+      | packagePsciSupport `elem` originalDeps = originalConfig
+      | otherwise = originalConfig { dependencies = packagePsciSupport : originalDeps }
+
     replAction purs = do
       Config{..} <- view (the @Config)
       deps <- Packages.getProjectDeps
-      -- we check that psci-support is in the deps, see #550
-      unless (Set.member (PackageName "psci-support") (Set.fromList (map fst deps))) $ do
-        die
-          [ "The package called 'psci-support' needs to be installed for the repl to work properly."
-          , "Run `spago install psci-support` to add it to your dependencies."
-          ]
       let
         globs =
           Packages.getGlobsSourcePaths $ Packages.getGlobs deps depsOnly (configSourcePaths <> sourcePaths)

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -223,7 +223,7 @@ repl newPackages sourcePaths pursArgs depsOnly = do
     ensurePsciSupportIncluded :: Config -> Config
     ensurePsciSupportIncluded originalConfig@Config{dependencies = originalDeps}
       | packagePsciSupport `elem` originalDeps = originalConfig
-      | otherwise = originalConfig { dependencies = packagePsciSupport : originalDeps }
+      | otherwise = originalConfig { dependencies = Set.insert packagePsciSupport originalDeps }
 
     replAction purs = do
       Config{..} <- view (the @Config)

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -161,7 +161,7 @@ parser = do
     nodeArgs         = many $ CLI.opt (Just . BackendArg) "node-args" 'a' "Argument to pass to node (run/test only)"
     backendArgs      = many $ CLI.opt (Just . BackendArg) "exec-args" 'b' "Argument to pass to the backend (run/test only)"
     dependencyPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'd' "Package name to add as a dependency"
-    replPackageName = PackageName <$> Opts.strOption (Opts.long "repl-package" <> Opts.value "psci-support" <> Opts.help "The REPL package to use for evaluating expressions")
+    replPackageName = PackageName <$> Opts.strOption (Opts.long "repl-package" <> Opts.value "psci-support" <> Opts.showDefault <> Opts.metavar "PACKAGE" <> Opts.help "The REPL package to use for evaluating expressions")
     scriptSource = CLI.arg Just "source" "Source file to run as script"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include (in addition to paths in spago.dhall)"
 

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -64,7 +64,7 @@ data Command
   | Build BuildOptions
 
   -- | Start a REPL
-  | Repl [PackageName] [SourcePath] [PursArg] DepsOnly
+  | Repl [PackageName] [SourcePath] [PursArg] DepsOnly PackageName
 
   -- | Generate documentation for the project and its dependencies
   | Docs (Maybe DocsFormat) [SourcePath] DepsOnly NoSearch OpenDocs
@@ -161,6 +161,7 @@ parser = do
     nodeArgs         = many $ CLI.opt (Just . BackendArg) "node-args" 'a' "Argument to pass to node (run/test only)"
     backendArgs      = many $ CLI.opt (Just . BackendArg) "exec-args" 'b' "Argument to pass to the backend (run/test only)"
     dependencyPackageNames = many $ CLI.opt (Just . PackageName) "dependency" 'd' "Package name to add as a dependency"
+    replPackageName = PackageName <$> Opts.strOption (Opts.long "repl-package" <> Opts.value "psci-support" <> Opts.help "The REPL package to use for evaluating expressions")
     scriptSource = CLI.arg Just "source" "Source file to run as script"
     sourcePaths      = many $ CLI.opt (Just . SourcePath) "path" 'p' "Source path to include (in addition to paths in spago.dhall)"
 
@@ -202,7 +203,7 @@ parser = do
     repl =
       ( "repl"
       , "Start a REPL"
-      , Repl <$> dependencyPackageNames <*> sourcePaths <*> pursArgs <*> depsOnly
+      , Repl <$> dependencyPackageNames <*> sourcePaths <*> pursArgs <*> depsOnly <*> replPackageName
       )
 
     execArgs = (++) <$> backendArgs <*> nodeArgs

--- a/templates/spago.dhall
+++ b/templates/spago.dhall
@@ -11,7 +11,7 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "my-project"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [ "console", "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/SpagoSpec.hs
+++ b/test/SpagoSpec.hs
@@ -154,7 +154,7 @@ spec = around_ setup $ do
 
       writeTextFile "psc-package.json" "{ \"name\": \"aaa\", \"depends\": [ \"prelude\" ], \"set\": \"foo\", \"source\": \"bar\" }"
       spago ["init"] >>= shouldBeSuccess
-      writeTextFile "spago.dhall" "{- Welcome to a Spago project!  You can edit this file as you like.  -} { name = \"my-project\" , dependencies = [ \"effect\", \"console\", \"psci-support\", \"a\", \"b\" ] , packages = ./packages.dhall // { a = { version = \"a1\", dependencies = [\"b\"], repo = \"https://github.com/fake/fake.git\" }, b = { version = \"b1\", dependencies = [\"a\"], repo = \"https://github.com/fake/fake.git\" } } }"
+      writeTextFile "spago.dhall" "{- Welcome to a Spago project!  You can edit this file as you like.  -} { name = \"my-project\" , dependencies = [ \"effect\", \"console\", \"a\", \"b\" ] , packages = ./packages.dhall // { a = { version = \"a1\", dependencies = [\"b\"], repo = \"https://github.com/fake/fake.git\" }, b = { version = \"b1\", dependencies = [\"a\"], repo = \"https://github.com/fake/fake.git\" } } }"
       spago ["install"] >>= shouldBeFailureStderr "circular-dependencies.txt"
 
     it "Spago should be able to install a package in the set from a commit hash" $ do
@@ -201,7 +201,7 @@ spec = around_ setup $ do
       spago ["init"] >>= shouldBeSuccess
       rm "spago.dhall"
       mkdir "nested"
-      writeTextFile "./nested/spago.dhall" "{ name = \"nested\", sources = [ \"src/**/*.purs\" ], dependencies = [ \"effect\", \"console\", \"psci-support\" ] , packages = ../packages.dhall }"
+      writeTextFile "./nested/spago.dhall" "{ name = \"nested\", sources = [ \"src/**/*.purs\" ], dependencies = [ \"effect\", \"console\",  ] , packages = ../packages.dhall }"
       spago ["install", "--config", "./nested/spago.dhall"] >>= shouldBeSuccess
 
     it "Spago should not change the alternative config if it does not change dependencies" $ do

--- a/test/fixtures/bump-version-bower.json
+++ b/test/fixtures/bump-version-bower.json
@@ -17,7 +17,6 @@
         "purescript-console": "^v4.2.0",
         "purescript-effect": "^v2.0.1",
         "purescript-prelude": "^v4.1.1",
-        "purescript-psci-support": "^v4.0.0",
         "purescript-tortellini": "^v5.1.0"
     }
 }

--- a/test/fixtures/sources-output.txt
+++ b/test/fixtures/sources-output.txt
@@ -1,6 +1,5 @@
 .spago/console/v5.0.0/src/**/*.purs
 .spago/effect/v3.0.0/src/**/*.purs
 .spago/prelude/v5.0.0/src/**/*.purs
-.spago/psci-support/v5.0.0/src/**/*.purs
 src/**/*.purs
 test/**/*.purs

--- a/test/fixtures/spago-bower-import.dhall
+++ b/test/fixtures/spago-bower-import.dhall
@@ -21,7 +21,6 @@ to generate this file without the comments in this block.
   , "foreign-object"
   , "nullable"
   , "prelude"
-  , "psci-support"
   , "record"
   , "typelevel-prelude"
   , "variant"

--- a/test/fixtures/spago-configV1.dhall
+++ b/test/fixtures/spago-configV1.dhall
@@ -4,6 +4,6 @@ You can edit this file as you like.
 -}
 { name = "aaa"
 , dependencies =
-  [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
+  [ "console", "effect", "foreign", "prelude", "simple-json" ]
 , packages = ./packages.dhall
 }

--- a/test/fixtures/spago-configV2.dhall
+++ b/test/fixtures/spago-configV2.dhall
@@ -4,7 +4,6 @@ You can edit this file as you like.
 -}
 { sources = [ "src/**/*.purs", "test/**/*.purs" ]
 , name = "aaa"
-, dependencies =
-  [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
+, dependencies = [ "console", "effect", "foreign", "prelude", "simple-json" ]
 , packages = ./packages.dhall
 }

--- a/test/fixtures/spago-configWithBackend.dhall
+++ b/test/fixtures/spago-configWithBackend.dhall
@@ -4,7 +4,7 @@ You can edit this file as you like.
 -}
 { backend = "echo hi from backend> alternate-backend-output.txt"
 , name = "aaa"
-, dependencies = [ "aff", "console", "effect", "psci-support" ]
+, dependencies = [ "aff", "console", "effect" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-install-failure.dhall
+++ b/test/fixtures/spago-install-failure.dhall
@@ -11,7 +11,7 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "aaa"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [ "console", "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-install-success.dhall
+++ b/test/fixtures/spago-install-success.dhall
@@ -11,8 +11,7 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "aaa"
-, dependencies =
-  [ "console", "effect", "foreign", "prelude", "psci-support", "simple-json" ]
+, dependencies = [ "console", "effect", "foreign", "prelude", "simple-json" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-no-comments.dhall
+++ b/test/fixtures/spago-no-comments.dhall
@@ -1,5 +1,5 @@
 { name = "my-project"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [ "console", "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-psc-failure.dhall
+++ b/test/fixtures/spago-psc-failure.dhall
@@ -11,7 +11,7 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "aaa"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [ "console", "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/test/fixtures/spago-psc-success.dhall
+++ b/test/fixtures/spago-psc-success.dhall
@@ -11,7 +11,7 @@ When creating a new Spago project, you can use
 to generate this file without the comments in this block.
 -}
 { name = "aaa"
-, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, dependencies = [ "console", "effect", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }


### PR DESCRIPTION
### Description of the change

Drops the need to have `psci-support` added to one's dependencies by always adding it when one runs `spago repl`. See the last point in [this comment](https://github.com/purescript/spago/issues/681#issuecomment-909243133) for more details.

~Note: This is not meant to be merged until AFTER #815~

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
