### PR TITLE
Convert deps & source paths from List to Set

### DIFF
--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -55,9 +55,9 @@ build maybePostBuild = do
   BuildOptions{..} <- view (the @BuildOptions)
   Config{..} <- view (the @Config)
   deps <- Packages.getProjectDeps
-  let partitionedGlobs@(Packages.Globs{..}) = Packages.getGlobs deps depsOnly configSourcePaths
+  let partitionedGlobs@(Packages.Globs{..}) = Packages.getGlobs deps depsOnly (toList configSourcePaths)
       allPsGlobs = Packages.getGlobsSourcePaths partitionedGlobs <> sourcePaths
-      allJsGlobs = Packages.getJsGlobs deps depsOnly configSourcePaths <> sourcePaths
+      allJsGlobs = Packages.getJsGlobs deps depsOnly (toList configSourcePaths) <> sourcePaths
 
       checkImports = do
         maybeGraph <- view (the @Graph)
@@ -103,7 +103,7 @@ build maybePostBuild = do
                     $ Set.toList importedPackageModules
 
                 dependencyPackages :: Set PackageName
-                dependencyPackages = Set.fromList dependencies
+                dependencyPackages = dependencies
 
               let
                 unusedPackages =
@@ -215,10 +215,10 @@ repl newPackages sourcePaths pursArgs depsOnly = do
 
         writeTextFile ".purs-repl" Templates.pursRepl
 
-        let dependencies = [ PackageName "effect", PackageName "console", PackageName "psci-support" ] <> newPackages
+        let dependencies = Set.fromList $ [ PackageName "effect", PackageName "console", PackageName "psci-support" ] <> newPackages
 
         config <- Run.withPursEnv NoPsa $ do
-          Config.makeTempConfig dependencies Nothing [] Nothing
+          Config.makeTempConfig dependencies Nothing Set.empty Nothing
 
         Run.withInstallEnv' (Just config) (replAction purs)
   where
@@ -233,7 +233,7 @@ repl newPackages sourcePaths pursArgs depsOnly = do
           ]
       let
         globs =
-          Packages.getGlobsSourcePaths $ Packages.getGlobs deps depsOnly (configSourcePaths <> sourcePaths)
+          Packages.getGlobsSourcePaths $ Packages.getGlobs deps depsOnly (toList $ configSourcePaths <> Set.fromList sourcePaths)
       Fetch.fetchPackages deps
       runRIO purs $ Purs.repl globs pursArgs
 
@@ -296,10 +296,10 @@ script modulePath tag packageDeps opts = do
   Turtle.mktree scriptDirPath
   Turtle.cd scriptDirPath
 
-  let dependencies = [ PackageName "effect", PackageName "console", PackageName "prelude" ] <> packageDeps
+  let dependencies = Set.fromList $ [ PackageName "effect", PackageName "console", PackageName "prelude" ] <> packageDeps
 
   config <- Run.withPursEnv NoPsa $ do
-    Config.makeTempConfig dependencies Nothing [ SourcePath absoluteModulePath ] tag
+    Config.makeTempConfig dependencies Nothing (Set.fromList [ SourcePath absoluteModulePath ]) tag
 
   let runDirs :: RunDirectories
       runDirs = RunDirectories scriptDirPath currentDir
@@ -430,7 +430,7 @@ docs format noSearch open = do
   Config{..} <- view (the @Config)
   deps <- Packages.getProjectDeps
   logInfo "Generating documentation for the project. This might take a while..."
-  Purs.docs docsFormat $ Packages.getGlobsSourcePaths (Packages.getGlobs deps depsOnly configSourcePaths) <> sourcePaths
+  Purs.docs docsFormat $ Packages.getGlobsSourcePaths (Packages.getGlobs deps depsOnly (toList configSourcePaths)) <> sourcePaths
 
   when isHTMLFormat $ do
     when (noSearch == AddSearch) $ do
@@ -469,7 +469,7 @@ search = do
 
   logInfo "Building module metadata..."
 
-  Purs.compile (Packages.getGlobsSourcePaths (Packages.getGlobs deps Packages.AllSources configSourcePaths))
+  Purs.compile (Packages.getGlobsSourcePaths (Packages.getGlobs deps Packages.AllSources (toList configSourcePaths)))
     [ PursArg "--codegen"
     , PursArg "docs"
     ]

--- a/src/Spago/Command/Ls.hs
+++ b/src/Spago/Command/Ls.hs
@@ -8,7 +8,6 @@ import Spago.Env
 
 import qualified Data.Aeson               as Json
 import qualified Data.Map                 as Map
-import qualified Data.Set                 as Set
 import qualified Data.Text                as Text
 import qualified Data.Text.Lazy           as LT
 import qualified Data.Text.Lazy.Encoding  as LT
@@ -50,7 +49,7 @@ listPackages packagesFilter jsonFlag = do
     IncludeTransitive -> Packages.getProjectDeps
     _ -> do
       Config { packageSet = PackageSet{ packagesDB }, dependencies } <- view (the @Config)
-      pure $ Map.toList $ Map.restrictKeys packagesDB (Set.fromList dependencies)
+      pure $ Map.toList $ Map.restrictKeys packagesDB dependencies
 
   case packagesToList of
     [] -> logWarn "There are no dependencies listed in your spago.dhall"

--- a/src/Spago/Config.hs
+++ b/src/Spago/Config.hs
@@ -125,8 +125,8 @@ parseConfig = do
       let ks = Dhall.extractRecordValues ks'
       let sourcesType  = Dhall.list (Dhall.auto :: Dhall.Decoder SourcePath)
       name              <- Dhall.requireTypedKey ks "name" Dhall.strictText
-      dependencies      <- Dhall.requireTypedKey ks "dependencies" dependenciesType
-      configSourcePaths <- Dhall.requireTypedKey ks "sources" sourcesType
+      dependencies      <- Set.fromList <$> Dhall.requireTypedKey ks "dependencies" dependenciesType
+      configSourcePaths <- Set.fromList <$> Dhall.requireTypedKey ks "sources" sourcesType
       alternateBackend  <- Dhall.maybeTypedKey ks "backend" Dhall.strictText
 
       let ensurePublishConfig = do
@@ -164,9 +164,9 @@ ensureConfig = do
 -- | For use by `spago script` and `spago repl`
 makeTempConfig
   :: (HasLogFunc env, HasPurs env)
-  => [PackageName]
+  => Set PackageName
   -> Maybe Text
-  -> [SourcePath]
+  -> Set SourcePath
   -> Maybe Text
   -> RIO env Config
 makeTempConfig dependencies alternateBackend configSourcePaths maybeTag = do

--- a/src/Spago/RunEnv.hs
+++ b/src/Spago/RunEnv.hs
@@ -205,7 +205,7 @@ getPackageSet = do
 getMaybeGraph :: HasPursEnv env => BuildOptions -> Config -> [(PackageName, Package)] -> RIO env Graph
 getMaybeGraph BuildOptions{ depsOnly, sourcePaths } Config{ configSourcePaths } deps = do
   logDebug "Running `getMaybeGraph`"
-  let partitionedGlobs = Packages.getGlobs deps depsOnly configSourcePaths
+  let partitionedGlobs = Packages.getGlobs deps depsOnly $ toList configSourcePaths
       globs = Packages.getGlobsSourcePaths partitionedGlobs <> sourcePaths
   supportsGraph <- Purs.hasMinPursVersion "0.14.0"
   if not supportsGraph

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -79,7 +79,7 @@ newtype ModuleName = ModuleName { unModuleName :: Text }
   deriving newtype (Eq, FromJSON, FromJSONKey, Ord)
 newtype TargetPath = TargetPath { unTargetPath :: Text }
 newtype SourcePath = SourcePath { unSourcePath :: Text }
-  deriving newtype (Show, Dhall.FromDhall)
+  deriving newtype (Eq, Ord, Show, Dhall.FromDhall)
 newtype PursArg = PursArg { unPursArg :: Text }
   deriving newtype (Eq, Show)
 newtype BackendArg = BackendArg { unBackendArg :: Text }
@@ -185,10 +185,10 @@ data ScriptBuildOptions = ScriptBuildOptions
 -- | Spago configuration file type
 data Config = Config
   { name              :: Text
-  , dependencies      :: [PackageName]
+  , dependencies      :: Set PackageName
   , packageSet        :: PackageSet
   , alternateBackend  :: Maybe Text
-  , configSourcePaths :: [SourcePath]
+  , configSourcePaths :: Set SourcePath
   , publishConfig     :: Either (Dhall.ReadError Void) PublishConfig
   } deriving (Show, Generic)
 


### PR DESCRIPTION
### Description of the change

Converts the `dependencies` and `configSourcePaths` types for `Config` from a `List` to a `Set`. See [this comment and the comments preceding it](https://github.com/purescript/spago/issues/813#issuecomment-908369678) for more context. We shouldn't pass the same source globs into `purs compile` or `purs repl` multiple times. By storing these values as a `Set`, we can add new items without fear of duplication.

I wasn't sure whether to include this in #817

~Note: This is not meant to be merged until AFTER #815~

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
