### PR TITLE
Replacing deprecated `request` for NPM install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 
 Other improvements:
 - CI: Add sha256 checksum generation on the release workflow (#816)
+- Replacing deprecated `request` by `make-fetch-happen` for NPM installation (#840)
 
 ## [0.20.3] - 2021-05-12
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const request = require("request");
+const fetch = require("make-fetch-happen");
 const tar = require("tar");
 const version = "PACKAGE_VERSION";
 const platform = { win32: "Windows", darwin: "macOS" }[process.platform] || "Linux";
 const url = `https://github.com/purescript/spago/releases/download/${version}/${platform}.tar.gz`
 
-request.get(url).pipe(tar.x({"C": './'}));
+fetch(url).then(res => res.body.pipe(tar.x({"C": './'})));

--- a/npm/package.json
+++ b/npm/package.json
@@ -15,8 +15,8 @@
     "spago": "./spago"
   },
   "dependencies": {
-    "request": "^2.88.0",
-    "tar": "^4.4.8"
+    "make-fetch-happen": "^9.1.0",
+    "tar": "^6.1.11"
   },
   "keywords": [
     "purescript",


### PR DESCRIPTION
### Description of the change

The `request`[^1] has been deprecated since **2020**, replacing with `make-fetch-happen`[^2] (**6,869,553** weekly downloads) which used by the `npm/cli` internally.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)


[^1]: https://www.npmjs.com/package/request
[^2]: https://www.npmjs.com/package/make-fetch-happen