### PR TITLE
Remove `run.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 Other improvements:
-- Remove run.js in preparation of `v0.15.0` release (#845)
+- Avoid writing a JS file when executing `spago run` (#845, #846)
 
 ## [0.20.4] - 2022-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- Remove run.js in preparation of `v0.15.0` release (#845)
+
 ## [0.20.4] - 2022-01-29
 
 Bugfixes:

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -343,6 +343,9 @@ runBackend maybeBackend RunDirectories{ sourceDir, executeDir } moduleName maybe
         ]
     nodeCmd outputPath'= "node -e \"" <> nodeContents outputPath' <> "\" " <> nodeArgs
     nodeAction outputPath' = do
+      -- cd to executeDir in case it isn't the same as sourceDir
+      logDebug $ "Executing from: " <> displayShow @FilePath executeDir
+      Turtle.cd executeDir
       -- We build a process by hand here because we need to forward the stdin to the backend process
       let processWithStdin = (Process.shell (Text.unpack $ nodeCmd outputPath')) { Process.std_in = Process.Inherit }
       Turtle.system processWithStdin empty >>= \case

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -347,6 +347,7 @@ runBackend maybeBackend RunDirectories{ sourceDir, executeDir } moduleName maybe
       logDebug $ "Executing from: " <> displayShow @FilePath executeDir
       Turtle.cd executeDir
       -- We build a process by hand here because we need to forward the stdin to the backend process
+      logDebug $ "Running node command: `" <> nodeCmd outputPath' <> "`"
       let processWithStdin = (Process.shell (Text.unpack $ nodeCmd outputPath')) { Process.std_in = Process.Inherit }
       Turtle.system processWithStdin empty >>= \case
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -347,7 +347,7 @@ runBackend maybeBackend RunDirectories{ sourceDir, executeDir } moduleName maybe
       logDebug $ "Executing from: " <> displayShow @FilePath executeDir
       Turtle.cd executeDir
       -- We build a process by hand here because we need to forward the stdin to the backend process
-      logDebug $ "Running node command: `" <> nodeCmd outputPath' <> "`"
+      logDebug $ "Running node command: `" <> (display $ nodeCmd outputPath') <> "`"
       let processWithStdin = (Process.shell (Text.unpack $ nodeCmd outputPath')) { Process.std_in = Process.Inherit }
       Turtle.system processWithStdin empty >>= \case
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage

--- a/test/fixtures/spago-run-args.purs
+++ b/test/fixtures/spago-run-args.purs
@@ -10,5 +10,5 @@ import Data.Show (show)
 main :: Effect Unit
 main = do
   args <- argv
-  -- dropping the first two args, node path and script name, to make test stable
-  log $ show $ drop 2 args
+  -- dropping the first arg, node path to make test stable
+  log $ show $ drop 1 args


### PR DESCRIPTION
### Description of the change

This removes the creation of a `run.js` file when running `spago run`. The file content is now passed as an argument to node. Solves #845 .

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
