### PR TITLE
Add install instruction using Homebrew to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Other installation methods available:
 - Download the binary from the [latest GitHub release][spago-latest-release]
 - Compile from source by cloning this repo and running `make install`
 - With Nix, using [easy-purescript-nix][spago-nix]
-- On FreeBSD, install with `pkg install hs-spago`.
+- On FreeBSD, install with `pkg install hs-spago`
+- On macOS, install with `brew install spago`
 
 **General notes:**
 - The assumption is that you already installed the [PureScript compiler][purescript].


### PR DESCRIPTION
I submitted a Homebrew formula to install Spago on macOS.  See also <https://github.com/Homebrew/homebrew-core/pull/94651>.

As it's a trivial change on the readme, I skipped the checklist.