### PR TITLE
Oh no, not libtinfo again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6] - 2022-02-09
+
+Bugfixes:
+- Oh no, not libtinfo again (#853, #854)
+
 ## [0.20.5] - 2022-02-08
 
 Features:

--- a/spago.cabal
+++ b/spago.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:           spago
-version:        0.20.5
+version:        0.20.6
 description:    Please see the README on GitHub at <https://github.com/purescript/spago#readme>
 homepage:       https://github.com/purescript/spago#readme
 bug-reports:    https://github.com/purescript/spago/issues

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,9 @@
-resolver: lts-17.15
+resolver: lts-18.24
 packages:
   - .
 extra-deps:
+  - Cabal-3.6.2.0
+  - process-1.6.13.1
   - dhall-1.39.0
   - semver-range-0.2.8
   - with-utf8-1.0.2.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: lts-18.24
+resolver: lts-17.15
 packages:
   - .
 extra-deps:
+  - dhall-1.39.0
   - semver-range-0.2.8
   - with-utf8-1.0.2.2
 allow-newer: true


### PR DESCRIPTION
Fix #853

It looks like `process-1.6.13.1` doesn't depend on libtinfo, but `process-1.6.13.2` does, so we pin to that.

That somehow means that we have to pin Cabal too. We got rid of the direct dependency on that, but now it's being brought in by a transitive package.
The chain seems to be
- `cabal-doctest -> Cabal`
- `system-filepath -> Cabal`
- `pretty-simple -> cabal-doctest`
- `system-fileio -> system-filepath`
- `turtle -> system-fileio`
- `dhall -> pretty-simple`

Having Cabal in the tree lenghtens CI times quite a bit so we should ideally get rid of it, but it's an involved fix so this is good enough for now.