### PR TITLE
Gh857 add run support for es modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Bugfixes
 - Make `spago run` work when `node-args` includes flag-like value (#856)
+Features:
+- Make `spago run` use es modules for projects >= v0.15 
 
 ## [0.20.6] - 2022-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Features:
+- Make `spago run` use es modules for projects >= v0.15 
+
 ## [0.20.7] - 2022-02-12
 
 Bugfixes
 - Make `spago run` work when `node-args` includes flag-like value (#856)
-Features:
-- Make `spago run` use es modules for projects >= v0.15 
 
 ## [0.20.6] - 2022-02-09
 


### PR DESCRIPTION
### Description of the change

This adds support for es modules to `spago run`, using es modules for versions >= v0.15
Solves #857 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
