### PR TITLE
fix(cabal file): set version bound on bower-json

### DIFF
--- a/spago.cabal
+++ b/spago.cabal
@@ -123,7 +123,7 @@ library
     , ansi-terminal
     , async-pool
     , base >=4.7 && <5
-    , bower-json
+    , bower-json >= 0.5.0.0
     , bytestring
     , containers
     , cryptonite


### PR DESCRIPTION
### Description of the change

I set an explicit lower version bound for the `bower-json` package in the `spago.cabal`file. Without the bound Cabal chooses `v0.4.0.0` which fails to compile due to type errors, as does `v0.4.0.1`. `v0.5.0.0` is the oldest version that compiles.

Environment:
 - GHC 8.10.6
 - Cabal 3.5.0.0
 - OpenBSD 7.0
