### PR TITLE
Add support for es modules bundling using esbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 Features:
+- Make `spago bundle-app` and `spago bundle-module` use esbuild and es modules for projects >= v0.15
 - Make `spago run` use es modules for projects >= v0.15 
 
 ## [0.20.7] - 2022-02-12

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -55,10 +55,8 @@ main = withUtf8 $ do
         -> Path.showPaths buildOptions whichPath
       Repl replPackageNames paths pursArgs depsOnly replPackage
         -> Spago.Build.repl replPackageNames paths pursArgs depsOnly replPackage
-      BundleApp modName tPath platform minify shouldBuild buildOptions
-        -> Run.withPursEnv globalUsePsa $ Spago.Build.bundleApp WithMain modName tPath platform minify shouldBuild buildOptions globalUsePsa
-      BundleModule modName tPath platform minify shouldBuild buildOptions
-        -> Run.withPursEnv globalUsePsa $ Spago.Build.bundleModule modName tPath platform minify shouldBuild buildOptions globalUsePsa
+      BundleModule withMain bundleOptions buildOptions
+        -> Run.withPursEnv globalUsePsa $ Spago.Build.bundleModule withMain bundleOptions buildOptions globalUsePsa
       Script modulePath tag dependencies scriptBuildOptions
         -> Spago.Build.script modulePath tag dependencies scriptBuildOptions
 

--- a/app/Spago.hs
+++ b/app/Spago.hs
@@ -55,10 +55,10 @@ main = withUtf8 $ do
         -> Path.showPaths buildOptions whichPath
       Repl replPackageNames paths pursArgs depsOnly replPackage
         -> Spago.Build.repl replPackageNames paths pursArgs depsOnly replPackage
-      BundleApp modName tPath shouldBuild buildOptions
-        -> Spago.Build.bundleApp WithMain modName tPath shouldBuild buildOptions globalUsePsa
-      BundleModule modName tPath shouldBuild buildOptions
-        -> Spago.Build.bundleModule modName tPath shouldBuild buildOptions globalUsePsa
+      BundleApp modName tPath platform minify shouldBuild buildOptions
+        -> Run.withPursEnv globalUsePsa $ Spago.Build.bundleApp WithMain modName tPath platform minify shouldBuild buildOptions globalUsePsa
+      BundleModule modName tPath platform minify shouldBuild buildOptions
+        -> Run.withPursEnv globalUsePsa $ Spago.Build.bundleModule modName tPath platform minify shouldBuild buildOptions globalUsePsa
       Script modulePath tag dependencies scriptBuildOptions
         -> Spago.Build.script modulePath tag dependencies scriptBuildOptions
 

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -376,7 +376,7 @@ runBackend maybeBackend RunDirectories{ sourceDir, executeDir } moduleName maybe
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage
         ExitFailure n -> die [ display failureMessage <> "Backend " <> displayShow backend <> " exited with error:" <> repr n ]
 
--- | Bundle the project to a js file or executable ES module
+-- | Bundle the project to a js file (CJS) or executable ES module
 bundleApp
   :: (HasEnv env, HasPurs env)
   => WithMain

--- a/src/Spago/Build.hs
+++ b/src/Spago/Build.hs
@@ -376,6 +376,36 @@ runBackend maybeBackend RunDirectories{ sourceDir, executeDir } moduleName maybe
         ExitSuccess   -> maybe (pure ()) (logInfo . display) maybeSuccessMessage
         ExitFailure n -> die [ display failureMessage <> "Backend " <> displayShow backend <> " exited with error:" <> repr n ]
 
+
+bundleWithEsbuild :: HasLogFunc env => WithMain -> ModuleName -> TargetPath -> Platform -> Minify -> RIO env ()
+bundleWithEsbuild withMain (ModuleName moduleName) (TargetPath targetPath) platform minify = do 
+  esbuild <- getESBuild
+  let 
+    platformOpt = case platform of 
+      Browser -> "browser"
+      Node -> "node"
+    minifyOpt = case minify of 
+      NoMinify -> ""
+      Minify -> " --minify"
+    cmd = case withMain of
+      WithMain -> 
+        "echo \"import { main } from './output/" <> moduleName <> "/index.js'\nmain()\" | "
+        <> esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle "
+        <> " --outfile=" <> targetPath
+      WithoutMain -> 
+        esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle " 
+        <> "output/" <> moduleName <> "/index.js" 
+        <> " --outfile=" <> targetPath
+  runWithOutput cmd
+    ("Bundle succeeded and output file to " <> targetPath)
+    "Bundle failed."
+  where
+  getESBuild = do
+    maybeESBuild <- findExecutable "esbuild"
+    case maybeESBuild of
+      Nothing -> die [ "Failed to find esbuild. See https://esbuild.github.io/getting-started/#install-esbuild for ways to install esbuild." ]
+      Just esBuild -> pure esBuild
+
 -- | Bundle the project to a js file (CJS) or executable ES module
 bundleApp
   :: (HasEnv env, HasPurs env)
@@ -391,9 +421,12 @@ bundleApp
 bundleApp withMain maybeModuleName maybeTargetPath maybePlatform minify noBuild buildOpts usePsa = do
   isES <- Purs.hasMinPursVersion "0.15.0"
   let 
-    moduleSystem = if isES then ESM else CJS
     (moduleName, targetPath, platform) = prepareBundleDefaults maybeModuleName maybeTargetPath maybePlatform
-    bundleAction = Purs.bundle moduleSystem withMain (withSourceMap buildOpts) moduleName targetPath platform minify
+    bundleAction =  
+      if isES then 
+        bundleWithEsbuild withMain moduleName targetPath platform minify
+      else 
+        Purs.bundle withMain (withSourceMap buildOpts) moduleName targetPath
   case noBuild of
     DoBuild -> Run.withBuildEnv usePsa buildOpts $ build (Just bundleAction)
     NoBuild -> Run.getEnv >>= (flip runRIO) bundleAction
@@ -416,13 +449,13 @@ bundleModule maybeModuleName maybeTargetPath maybePlatform minify noBuild buildO
     (moduleName, targetPath, platform) = prepareBundleDefaults maybeModuleName maybeTargetPath maybePlatform
     bundleAction = 
       if isES then
-        Purs.bundle ESM WithoutMain (withSourceMap buildOpts) moduleName targetPath platform minify
+        bundleWithEsbuild WithoutMain moduleName targetPath platform minify
       else
         let
           jsExport = Text.unpack $ "\nmodule.exports = PS[\""<> unModuleName moduleName <> "\"];"
         in do
             logInfo "Bundling first..."
-            Purs.bundle CJS WithoutMain (withSourceMap buildOpts) moduleName targetPath platform minify
+            Purs.bundle WithoutMain (withSourceMap buildOpts) moduleName targetPath
             -- Here we append the CommonJS export line at the end of the bundle
             try (with
                   (appendonly $ pathFromText $ unTargetPath targetPath)

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -79,11 +79,8 @@ data Command
   -- | Test the project with some module, default Test.Main
   | Test (Maybe ModuleName) BuildOptions [BackendArg]
 
-  -- | Bundle the project into an executable
-  | BundleApp (Maybe ModuleName) (Maybe TargetPath) (Maybe Platform) Minify NoBuild BuildOptions
-
   -- | Bundle a module into a CommonJS or ES module
-  | BundleModule (Maybe ModuleName) (Maybe TargetPath) (Maybe Platform) Minify NoBuild BuildOptions
+  | BundleModule WithMain BundleOptions BuildOptions
 
   -- | Verify that a single package is consistent with the Package Set
   | Verify PackageName
@@ -177,6 +174,7 @@ parser = do
     pursArgs        = many $ CLI.opt (Just . PursArg) "purs-args" 'u' "Arguments to pass to purs compile. Wrap in quotes."
     buildOptions  = BuildOptions <$> watch <*> clearScreen <*> allowIgnored <*> sourcePaths <*> srcMapFlag <*> noInstall
                     <*> pursArgs <*> depsOnly <*> beforeCommands <*> thenCommands <*> elseCommands
+    bundleOptions = BundleOptions <$> mainModule <*> toTarget <*> platform <*> minifyFlag <*> noBuild
     scriptBuildOptions = ScriptBuildOptions <$> pursArgs <*> beforeCommands <*> thenCommands <*> elseCommands
 
     -- Opts.flag' creates a parser with no default value. This is intended.
@@ -230,13 +228,13 @@ parser = do
     bundleApp =
       ( "bundle-app"
       , "Bundle the project into an executable"
-      , BundleApp <$> mainModule <*> toTarget <*> platform <*> minifyFlag <*> noBuild <*> buildOptions
+      , BundleModule WithMain <$> bundleOptions <*> buildOptions
       )
 
     bundleModule =
       ( "bundle-module"
-      , "Bundle the project into a CommonJS module"
-      , BundleModule <$> mainModule <*> toTarget <*> platform <*> minifyFlag <*> noBuild <*> buildOptions
+      , "Bundle the project into a module"
+      , BundleModule WithoutMain <$> bundleOptions <*> buildOptions
       )
 
     docs =

--- a/src/Spago/CLI.hs
+++ b/src/Spago/CLI.hs
@@ -80,10 +80,10 @@ data Command
   | Test (Maybe ModuleName) BuildOptions [BackendArg]
 
   -- | Bundle the project into an executable
-  | BundleApp (Maybe ModuleName) (Maybe TargetPath) NoBuild BuildOptions
+  | BundleApp (Maybe ModuleName) (Maybe TargetPath) (Maybe Platform) Minify NoBuild BuildOptions
 
-  -- | Bundle a module into a CommonJS module
-  | BundleModule (Maybe ModuleName) (Maybe TargetPath) NoBuild BuildOptions
+  -- | Bundle a module into a CommonJS or ES module
+  | BundleModule (Maybe ModuleName) (Maybe TargetPath) (Maybe Platform) Minify NoBuild BuildOptions
 
   -- | Verify that a single package is consistent with the Package Set
   | Verify PackageName
@@ -156,6 +156,13 @@ parser = do
 
     mainModule  = CLI.optional $ CLI.opt (Just . ModuleName) "main" 'm' "Module to be used as the application's entry point"
     toTarget    = CLI.optional $ CLI.opt (Just . TargetPath) "to" 't' "The target file path"
+    platform =
+      let wrap = \case
+            "node" -> Just Node
+            "browser" -> Just Browser
+            _ -> Nothing
+      in CLI.optional $ CLI.opt wrap "platform" 'p' "Bundle platform 'browser' (default) or 'node'"
+    minifyFlag     = bool NoMinify Minify <$> CLI.switch "minify" 'y' "Minifies the bundle"
     docsFormat  = CLI.optional $ CLI.opt Purs.parseDocsFormat "format" 'f' "Docs output format (markdown | html | etags | ctags)"
     jobsLimit   = CLI.optional (CLI.optInt "jobs" 'j' "Limit the amount of jobs that can run concurrently")
     nodeArgs         = many $ CLI.opt (Just . BackendArg) "node-args" 'a' "Argument to pass to node (run/test only)"
@@ -223,13 +230,13 @@ parser = do
     bundleApp =
       ( "bundle-app"
       , "Bundle the project into an executable"
-      , BundleApp <$> mainModule <*> toTarget <*> noBuild <*> buildOptions
+      , BundleApp <$> mainModule <*> toTarget <*> platform <*> minifyFlag <*> noBuild <*> buildOptions
       )
 
     bundleModule =
       ( "bundle-module"
       , "Bundle the project into a CommonJS module"
-      , BundleModule <$> mainModule <*> toTarget <*> noBuild <*> buildOptions
+      , BundleModule <$> mainModule <*> toTarget <*> platform <*> minifyFlag <*> noBuild <*> buildOptions
       )
 
     docs =

--- a/src/Spago/Prelude.hs
+++ b/src/Spago/Prelude.hs
@@ -66,7 +66,7 @@ module Spago.Prelude
   , viewShell
   , findExecutableOrDie
   , findExecutable
-
+  , runWithOutput
   -- * Other
   , Dhall.Core.throws
   , repr
@@ -263,6 +263,13 @@ findExecutable x =
       success -> pure success
     _ -> Directory.findExecutable x
 
+-- | Run the given command.
+runWithOutput :: HasLogFunc env => Text -> Text -> Text -> RIO env ()
+runWithOutput command success failure = do
+  logDebug $ "Running command: `" <> display command <> "`"
+  shell command empty >>= \case
+    ExitSuccess -> logInfo $ display success
+    ExitFailure _ -> die [ display failure ]
 
 -- | Return the full path of the executable we're trying to call,
 --   or die trying

--- a/src/Spago/Purs.hs
+++ b/src/Spago/Purs.hs
@@ -83,26 +83,26 @@ getESBuild = do
 
 bundle :: HasLogFunc env => ModuleSystem -> WithMain -> WithSrcMap -> ModuleName -> TargetPath -> Platform -> Minify -> RIO env ()
 bundle ESM withMain _ (ModuleName moduleName) (TargetPath targetPath) platform minify = do
-      esbuild <- getESBuild
-      let 
-        platformOpt = case platform of 
-          Browser -> "browser"
-          Node -> "node"
-        minifyOpt = case minify of 
-          NoMinify -> ""
-          Minify -> " --minify"
-        cmd = case withMain of
-          WithMain -> 
-            "echo \"import { main } from './output/" <> moduleName <> "/index.js'\nmain()\" | "
-            <> esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle "
-            <> " --outfile=" <> targetPath
-          WithoutMain -> 
-            esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle " 
-            <> "output/" <> moduleName <> "/index.js" 
-            <> " --outfile=" <> targetPath
-      runWithOutput cmd
-        ("Bundle succeeded and output file to " <> targetPath)
-        "Bundle failed."
+  esbuild <- getESBuild
+  let 
+    platformOpt = case platform of 
+      Browser -> "browser"
+      Node -> "node"
+    minifyOpt = case minify of 
+      NoMinify -> ""
+      Minify -> " --minify"
+    cmd = case withMain of
+      WithMain -> 
+        "echo \"import { main } from './output/" <> moduleName <> "/index.js'\nmain()\" | "
+        <> esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle "
+        <> " --outfile=" <> targetPath
+      WithoutMain -> 
+        esbuild <> " --platform=" <> platformOpt <> minifyOpt <> " --bundle " 
+        <> "output/" <> moduleName <> "/index.js" 
+        <> " --outfile=" <> targetPath
+  runWithOutput cmd
+    ("Bundle succeeded and output file to " <> targetPath)
+    "Bundle failed."
 bundle CJS withMain withSourceMap (ModuleName moduleName) (TargetPath targetPath) _ _ = do
   let 
     main = case withMain of

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -85,8 +85,6 @@ newtype PursArg = PursArg { unPursArg :: Text }
 newtype BackendArg = BackendArg { unBackendArg :: Text }
   deriving newtype (Eq)
 
-data ModuleSystem = ESM | CJS
-
 data WithMain = WithMain | WithoutMain
 
 data WithSrcMap = WithSrcMap | WithoutSrcMap

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -85,9 +85,15 @@ newtype PursArg = PursArg { unPursArg :: Text }
 newtype BackendArg = BackendArg { unBackendArg :: Text }
   deriving newtype (Eq)
 
+data ModuleSystem = ESM | CJS
+
 data WithMain = WithMain | WithoutMain
 
 data WithSrcMap = WithSrcMap | WithoutSrcMap
+
+data Platform = Browser | Node 
+
+data Minify = Minify | NoMinify
 
 data CacheFlag = SkipCache | NewCache
   deriving (Eq)

--- a/src/Spago/Types.hs
+++ b/src/Spago/Types.hs
@@ -169,6 +169,14 @@ defaultBuildOptions = BuildOptions
   , elseCommands = []
   }
 
+data BundleOptions = BundleOptions
+  { maybeModuleName :: Maybe ModuleName
+  , maybeTargetPath :: Maybe TargetPath
+  , maybePlatform :: Maybe Platform
+  , minify :: Minify
+  , noBuild :: NoBuild
+  }
+
 fromScriptOptions :: BuildOptions -> ScriptBuildOptions -> BuildOptions
 fromScriptOptions opts ScriptBuildOptions{..} = opts
   { pursArgs = pursArgs


### PR DESCRIPTION
### Description of the change

Solves #861 

- v0.14 bundling uses cjs and `purs bundle`
- v0.15 bundling uses es modules and `esbuild`

### Checklist:

- [X] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
