### PR TITLE
Retry git clone (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
 - Make `spago bundle-app` and `spago bundle-module` use esbuild and es modules for projects >= v0.15
 - Make `spago run` use es modules for projects >= v0.15 
 - Support Glibc versions >= `2.24`
+- Retry git clone up to two times
 
 ## [0.20.7] - 2022-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Features:
 - Make `spago bundle-app` and `spago bundle-module` use esbuild and es modules for projects >= v0.15
 - Make `spago run` use es modules for projects >= v0.15 
 - Support Glibc versions >= `2.24`
-- Retry git clone up to two times
+- Retry git clone up to two times (#834, #873)
 
 ## [0.20.7] - 2022-02-12
 


### PR DESCRIPTION
Retry git clone in case there are intermittent connection failures, based on the suggested solution in https://github.com/purescript/spago/issues/834.

I came across this issue and tested the change during a time when Github connections were occasionally failing and it successfully retried.  I also tested against a local server and spago tried to connect 3 times with this change and 1 without.
