### PR TITLE
Fix for non-zero Windows npm/npx exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+- Windows: forward the proper exit code when running spago via NPM (#883)
+
 ## [0.20.9] - 2022-05-03
 
 Bugfixes:

--- a/npm/spago
+++ b/npm/spago
@@ -12,3 +12,6 @@ const spago = cp.spawn(__dirname + '/spago.exe', process.argv.slice(2), {stdio: 
 spago.on('error', (err) => {
     console.log("Downloading the spago binary failed. Please try reinstalling the spago npm package.");
 });
+spago.on('exit', (code) => {
+    process.exit(code);
+});


### PR DESCRIPTION
### Description of the change

Adjust the node.js script for launching spago when running on Windows so that exit codes are forwarded.  Fixes #883.

I would have liked to implement better testing by e.g., adjusting the `spago` function in test/Utils.hs to use `npx spago` or just invoke `node` directly pointed to the `spago` file - hopefully to observe a test failure with the old code and success with the new code.  But I wasn't able to understand how the test setup worked to try that out. 

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)