### PR TITLE
Spaghetto: support importing packages from the registry in the `extra_packages`

### DIFF
--- a/spaghetto/spago.yaml
+++ b/spaghetto/spago.yaml
@@ -53,39 +53,7 @@ workspace:
     # url: https://raw.githubusercontent.com/purescript/registry/main/package-sets/0.0.2.json
     registry: 0.0.2
   extra_packages:
+    dodo-printer: 2.2.1
     registry-dev:
       git: https://github.com/purescript/registry-dev.git
       ref: 04364360f1e5a91173f3b88a5e807773dc06aca5
-    dodo-printer:
-      git: https://github.com/natefaubion/purescript-dodo-printer.git
-      ref: 831c5c963a57ca4bfd62f96335267d7d0785851d
-      dependencies:
-        - aff
-        - ansi
-        - arrays
-        - avar
-        - console
-        - control
-        - effect
-        - either
-        - exceptions
-        - foldable-traversable
-        - integers
-        - lists
-        - maybe
-        - minibench
-        - newtype
-        - node-buffer
-        - node-child-process
-        - node-fs-aff
-        - node-path
-        - node-process
-        - node-streams
-        - parallel
-        - partial
-        - posix-types
-        - prelude
-        - safe-coerce
-        - strings
-        - tuples
-


### PR DESCRIPTION
..where previously only git repos were supported