### PR TITLE
Version parsing fixes

### DIFF
--- a/spaghetto/src/Spago/Git.purs
+++ b/spaghetto/src/Spago/Git.purs
@@ -76,7 +76,7 @@ isIgnored path = do
 
 getGit :: forall a. Spago (LogEnv a) Git
 getGit = do
-  Cmd.exec "git" [ "-v" ] Cmd.defaultExecOptions { pipeStdout = false, pipeStderr = false } >>= case _ of
+  Cmd.exec "git" [ "--version" ] Cmd.defaultExecOptions { pipeStdout = false, pipeStderr = false } >>= case _ of
     Right r -> pure { cmd: "git", version: r.stdout }
     Left err -> do
       logDebug $ show err

--- a/spaghetto/src/Spago/Purs.purs
+++ b/spaghetto/src/Spago/Purs.purs
@@ -38,6 +38,7 @@ getPurs =
     Left err -> do
       logDebug $ show err
       die [ "Failed to find purs. Have you installed it, and is it in your PATH?" ]
+    -- Drop the stuff after a space: dev builds look like this: 0.15.6 [development build; commit: 8da7e96005f717f03d6eee3c12b1f1416659a919]
     Right r -> case Version.parseVersion Version.Lenient (fromMaybe "" (Array.head (String.split (String.Pattern " ") r.stdout))) of
       Left _err -> die $ "Failed to parse purs version. Was: " <> r.stdout
       -- Fail if Purs is lower than 0.15.4

--- a/spaghetto/src/Spago/Purs.purs
+++ b/spaghetto/src/Spago/Purs.purs
@@ -2,7 +2,10 @@ module Spago.Purs where
 
 import Spago.Prelude
 
+import Data.Array as Array
+import Data.Maybe (fromMaybe)
 import Data.Set as Set
+import Data.String as String
 import Registry.Version (Version)
 import Registry.Version as Version
 import Spago.Cmd as Cmd
@@ -35,7 +38,7 @@ getPurs =
     Left err -> do
       logDebug $ show err
       die [ "Failed to find purs. Have you installed it, and is it in your PATH?" ]
-    Right r -> case Version.parseVersion Version.Lenient r.stdout of
+    Right r -> case Version.parseVersion Version.Lenient (fromMaybe "" (Array.head (String.split (String.Pattern " ") r.stdout))) of
       Left _err -> die $ "Failed to parse purs version. Was: " <> r.stdout
       -- Fail if Purs is lower than 0.15.4
       Right v ->


### PR DESCRIPTION
Quick fixes to get it working for me again:
- My version of git, 2.36.1, ironically does not have the `-v` flag
- Drop the purs version string after a space, to accomodate dev builds which have a version string like `0.15.6 [development build; commit: 8da7e96005f717f03d6eee3c12b1f1416659a919]`