### PR TITLE
Upgrade `make-fetch-happen` to `^11.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bugfixes:
 
 Other improvements:
 - CI: cleanup CI for 0.15.0 PureScript updates (#879)
+- Install: upgrade `make-fetch-happen` to `^11.0.1` (#925)
 
 ## [0.20.9] - 2022-05-03
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -15,7 +15,7 @@
     "spago": "./spago"
   },
   "dependencies": {
-    "make-fetch-happen": "^9.1.0",
+    "make-fetch-happen": "^11.0.1",
     "tar": "^6.1.11"
   },
   "keywords": [


### PR DESCRIPTION
### Description of the change

To address the following warning:

```
npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
```

Here is the dependency chain:

```
└─┬ spago@0.20.9
  └─┬ make-fetch-happen@9.1.0
    └─┬ cacache@15.3.0
      └── @npmcli/move-file@1.1.2
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

<!--
**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
-->