### PR TITLE
Fix 'not in index' error in Fetch.purs

### DIFF
--- a/spaghetto/src/Spago/Command/Fetch.purs
+++ b/spaghetto/src/Spago/Command/Fetch.purs
@@ -250,7 +250,7 @@ getTransitiveDeps deps = do
   when (not (Set.isEmpty errors.notInPackageSet)) do
     die $ "The following packages do not exist in your package set:\n" <> foldMap printPackageError errors.notInPackageSet
   when (not (Set.isEmpty errors.notInIndex)) do
-    die $ "The following packages do not exist in the package index:\n" <> foldMap printPackageError errors.notInPackageSet
+    die $ "The following packages do not exist in the package index:\n" <> foldMap printPackageError errors.notInIndex
   pure packages
 
 widestRange :: Range


### PR DESCRIPTION
### Description of the change

The registry is currently failing to build and Spago is producing the error:

```
➜ spago build
Refreshing the Registry Index...
Reading Spago workspace configuration...
Read the package set from the registry

✅ Selecting 4 packages to build:
    registry-app
    registry-foreign
    registry-lib
    registry-scripts

The following packages do not exist in the package index:

```

This empty error is happening because of a typo in Fetch.purs.