### PR TITLE
Remove bin/index.js since it is no longer usable

### DIFF
--- a/spaghetto/bin/index.js
+++ b/spaghetto/bin/index.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-
-import { main } from "./bundle.js";
-
-main();


### PR DESCRIPTION
bundle.js calls main directly and does not export it