### PR TITLE
Fix NodeJS version parsing

### DIFF
--- a/spaghetto/src/Spago/Command/Run.purs
+++ b/spaghetto/src/Spago/Command/Run.purs
@@ -45,7 +45,7 @@ nodeVersion =
     Left err -> do
       logDebug $ show err
       die [ "Failed to find node. Have you installed it, and is it in your PATH?" ]
-    Right r -> case Version.parse r.stdout of
+    Right r -> case Version.parse $ fromMaybe r.stdout (String.stripPrefix (String.Pattern "v") r.stdout) of
       Left _err -> die $ "Failed to parse NodeJS version. Was: " <> r.stdout
       Right v ->
         if Version.major v >= 13 then


### PR DESCRIPTION
Quick fix for NodeJS version parsing by stripping the `v` prefix. I verified that this runs locally.

The full LenientVersion parsing in the registry does a few more things, but it's in the app directory:

https://github.com/purescript/registry-dev/blob/c0f9f65371a7f8baf0335272c14164d318b6f37f/app/src/App/Legacy/LenientVersion.purs#L61-L69