### PR TITLE
Parse legacy package set version with leading v

### DIFF
--- a/spaghetto/src/Spago/Config.purs
+++ b/spaghetto/src/Spago/Config.purs
@@ -536,7 +536,9 @@ readWorkspace maybeSelectedPackage = do
                     Right (LegacyPackageSet set) -> do
                       logDebug "Read legacy package set from URL"
                       version <- case Map.lookup (unsafeFromRight (PackageName.parse "metadata")) set of
-                        Just { version } -> pure (unsafeFromRight (Version.parse version))
+                        Just { version } -> do
+                          let version' = fromMaybe version (String.stripPrefix (String.Pattern "v") version) 
+                          pure (unsafeFromRight (Version.parse version'))
                         Nothing -> die $ "Couldn't find 'metadata' package in legacy package set."
                       pure { compiler: version, remotePackageSet: map RemoteLegacyPackage set }
       result <- case maybeHash of


### PR DESCRIPTION
Quick fix to unbreak parsing of legacy package sets, where metadata version is eg. v0.15.7

### Description of the change

TODO

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
