### PR TITLE
Fix run path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Bugfixes:
 - Windows: forward the proper exit code when running spago via NPM (#883, #884)
+- Windows: replace all backward slashes in run path
 
 Other improvements:
 - CI: cleanup CI for 0.15.0 PureScript updates (#879)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Bugfixes:
 - Windows: forward the proper exit code when running spago via NPM (#883, #884)
-- Windows: replace all backward slashes in run path
 
 Other improvements:
 - CI: cleanup CI for 0.15.0 PureScript updates (#879)

--- a/spaghetto/src/Spago/Command/Run.purs
+++ b/spaghetto/src/Spago/Command/Run.purs
@@ -78,7 +78,7 @@ run = do
         nodeContents =
           Array.fold
             [ "import { main } from 'file://"
-            , String.replace (Pattern "\\") (Replacement "/") opts.sourceDir
+            , String.replaceAll (Pattern "\\") (Replacement "/") opts.sourceDir
             , "/"
             , fromMaybe "output" workspace.buildOptions.output
             , "/"


### PR DESCRIPTION
### Description of the change

Bug: `sourceDir` part of the path in `.spago\run\run.js` gets only first backslash replaced. When run the remaining backslashes are discarded as escape symbols
```
       |---------|
file://c:\Aa\Bb\Cc/output/Main/index.js
file://c:/AaBbCc/output/Main/index.js
       |-------|
```
Fix: all backslashes are replaced
```
file://c:\Aa\Bb\Cc/output/Main/index.js
file://c:/Aa/Bb/Cc/output/Main/index.js
       |---------|
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)