### PR TITLE
spago@next: ls command

### DIFF
--- a/spaghetto/bin/src/Flags.purs
+++ b/spaghetto/bin/src/Flags.purs
@@ -75,12 +75,17 @@ json =
     # ArgParser.boolean
     # ArgParser.default false
 
-transitive ∷ ArgParser Boolean
+-- TODO: Discuss if we want to use sum types for flags or go with boolean
+-- Depending on the decision, revert or change the json flag, too
+data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
+
+transitive ∷ ArgParser IncludeTransitive
 transitive =
   ArgParser.flag [ "--transitive", "-t" ]
     "Include transitive dependencies"
     # ArgParser.boolean
     # ArgParser.default false
+    # map (if _ then IncludeTransitive else NoIncludeTransitive)
 
 pedanticPackages ∷ ArgParser Boolean
 pedanticPackages =

--- a/spaghetto/bin/src/Flags.purs
+++ b/spaghetto/bin/src/Flags.purs
@@ -75,17 +75,12 @@ json =
     # ArgParser.boolean
     # ArgParser.default false
 
--- TODO: Discuss if we want to use sum types for flags or go with boolean
--- Depending on the decision, revert or change the json flag, too
-data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
-
-transitive ∷ ArgParser IncludeTransitive
+transitive ∷ ArgParser Boolean
 transitive =
   ArgParser.flag [ "--transitive", "-t" ]
     "Include transitive dependencies"
     # ArgParser.boolean
     # ArgParser.default false
-    # map (if _ then IncludeTransitive else NoIncludeTransitive)
 
 pedanticPackages ∷ ArgParser Boolean
 pedanticPackages =

--- a/spaghetto/bin/src/Flags.purs
+++ b/spaghetto/bin/src/Flags.purs
@@ -70,8 +70,15 @@ noColor =
 
 json ∷ ArgParser Boolean
 json =
-  ArgParser.flag [ "--json" ]
+  ArgParser.flag [ "--json", "-j" ]
     "Format the output as JSON"
+    # ArgParser.boolean
+    # ArgParser.default false
+
+transitive ∷ ArgParser Boolean
+transitive =
+  ArgParser.flag [ "--transitive", "-t" ]
+    "Include transitive dependencies"
     # ArgParser.boolean
     # ArgParser.default false
 

--- a/spaghetto/bin/src/Flags.purs
+++ b/spaghetto/bin/src/Flags.purs
@@ -70,14 +70,14 @@ noColor =
 
 json ∷ ArgParser Boolean
 json =
-  ArgParser.flag [ "--json", "-j" ]
+  ArgParser.flag [ "--json" ]
     "Format the output as JSON"
     # ArgParser.boolean
     # ArgParser.default false
 
 transitive ∷ ArgParser Boolean
 transitive =
-  ArgParser.flag [ "--transitive", "-t" ]
+  ArgParser.flag [ "--transitive" ]
     "Include transitive dependencies"
     # ArgParser.boolean
     # ArgParser.default false

--- a/spaghetto/bin/src/Main.purs
+++ b/spaghetto/bin/src/Main.purs
@@ -21,6 +21,7 @@ import Registry.Constants as Registry.Constants
 import Registry.ManifestIndex as ManifestIndex
 import Registry.Metadata as Metadata
 import Registry.PackageName as PackageName
+import Spago.Bin.Flags (IncludeTransitive)
 import Spago.Bin.Flags as Flag
 import Spago.Bin.Flags as Flags
 import Spago.BuildInfo as BuildInfo
@@ -28,7 +29,7 @@ import Spago.Command.Build as Build
 import Spago.Command.Bundle as Bundle
 import Spago.Command.Fetch as Fetch
 import Spago.Command.Init as Init
-import Spago.Command.Ls (IncludeTransitive(..), JsonFlag(..))
+import Spago.Command.Ls (JsonFlag(..))
 import Spago.Command.Ls as Ls
 import Spago.Command.Registry as Registry
 import Spago.Command.Run as Run
@@ -141,7 +142,7 @@ type LsPackagesArgs =
 
 type LsDepsArgs =
   { json :: Boolean
-  , transitive :: Boolean
+  , transitive :: IncludeTransitive
   }
 
 data SpagoCmd a = SpagoCmd GlobalArgs (Command a)
@@ -451,15 +452,14 @@ main =
             lsEnv <- runSpago env (mkLsEnv dependencies)
             let j = if args.json then JsonOutputYes else JsonOutputNo
             runSpago lsEnv (Ls.listPackageSet j)
-          LsDeps args -> do
+          LsDeps args@{ transitive } -> do
             let fetchArgs = { packages: mempty, selectedPackage: Nothing, ensureRanges: false }
             { env, fetchOpts } <- mkFetchEnv fetchArgs
             -- TODO: --no-fetch flag
             dependencies <- runSpago env (Fetch.run fetchOpts)
             lsEnv <- runSpago env (mkLsEnv dependencies)
-            let t = if args.transitive then IncludeTransitive else NoIncludeTransitive
             let j = if args.json then JsonOutputYes else JsonOutputNo
-            runSpago lsEnv (Ls.listPackages t j)
+            runSpago lsEnv (Ls.listPackages transitive j)
 
 mkLogOptions :: GlobalArgs -> Aff LogOptions
 mkLogOptions { noColor, quiet, verbose } = do

--- a/spaghetto/src/Spago/Command/Ls.purs
+++ b/spaghetto/src/Spago/Command/Ls.purs
@@ -48,17 +48,17 @@ jsonPackageOutputCodec = CAR.object "JsonPackageOutput"
   }
 
 listPackageSet :: LsPackagesArgs -> Spago LsEnv Unit
-listPackageSet { json: jsonFlag } = do
+listPackageSet { json } = do
   logDebug "Running `listPackageSet`"
   { workspace } <- ask
-  output $ formatPackageNames jsonFlag (Map.toUnfoldable workspace.packageSet)
+  output $ formatPackageNames json (Map.toUnfoldable workspace.packageSet)
 
 listPackages :: LsDepsArgs -> Spago LsEnv Unit
-listPackages { transitive: packagesFilter, json: jsonFlag } = do
+listPackages { transitive, json } = do
   logDebug "Running `listPackages`"
   { dependencies, workspace } <- ask
   let
-    packagesToList = Map.toUnfoldable case packagesFilter of
+    packagesToList = Map.toUnfoldable case transitive of
       true -> dependencies
       false ->
         let
@@ -69,10 +69,10 @@ listPackages { transitive: packagesFilter, json: jsonFlag } = do
           filterKeys (_ `elem` directDependencies) dependencies
   case packagesToList of
     [] -> logWarn "There are no dependencies listed in your spago.dhall"
-    _ -> output $ formatPackageNames jsonFlag packagesToList
+    _ -> output $ formatPackageNames json packagesToList
 
 formatPackageNames :: forall a. Boolean -> Array (PackageName /\ Package) -> OutputFormat a
-formatPackageNames = case _ of
+formatPackageNames json = case json of
   true -> OutputLines <<< formatPackageNamesJson
   false -> OutputLines <<< formatPackageNamesText
   where
@@ -91,7 +91,6 @@ formatPackageNames = case _ of
   formatPackageNamesText :: Array (PackageName /\ Package) -> Array String
   formatPackageNamesText pkgs =
     let
-
       -- TODO: Currently prints git/remote packages as local packages
       showLocation :: PackageName -> Package -> String
       showLocation _ (GitPackage gitPackage) = "Remote " <> surroundQuote gitPackage.git

--- a/spaghetto/src/Spago/Command/Ls.purs
+++ b/spaghetto/src/Spago/Command/Ls.purs
@@ -1,3 +1,47 @@
-module Spago.Command.Ls where
+module Spago.Command.Ls (listPackages, IncludeTransitive(..)) where
 
-import Prelude
+import Spago.Prelude
+
+import Data.Map as Map
+import Data.Traversable (traverse_)
+import Data.Tuple.Nested (type (/\), (/\))
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Spago.Command.Build (BuildEnv)
+import Spago.Command.Registry (RegistryEnv)
+import Spago.Config (Package)
+
+data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
+
+type Env = { dependencies :: Map PackageName Package }
+
+listPackages :: forall a. IncludeTransitive -> String -> Spago Env Unit
+listPackages includeTransitive jsonFlag = do
+  -- logDebug "Running `listPackages`"
+  { dependencies } <- ask
+  let packagesToList = Map.toUnfoldable dependencies
+  case packagesToList of
+    -- [] -> logWarn "There are no dependencies listed in your spago.dhall"
+    [] -> pure unit
+    _ -> output $ OutputLines $ formatPackageNames jsonFlag packagesToList
+
+formatPackageNames :: String -> Array (PackageName /\ Package) -> Array String
+formatPackageNames jsonFlag packagesToList = render <$> packagesToList
+  where
+  render (packageName /\ _) = PackageName.print packageName
+
+-- listPackages :: forall a. IncludeTransitive -> String -> Spago (RegistryEnv a) Unit
+-- listPackages packagesFilter jsonFlag = do
+--   logDebug "Running `listPackages`"
+--   packagesToList :: List (PackageName /\ Package) <- case packagesFilter of
+--     IncludeTransitive -> Packages.getProjectDeps
+--     _ -> do
+--       { workspace } <- ask
+
+--       let packagesDB = config.packageSet.packagesDB
+--       let dependencies = config.dependencies
+--       pure $ Map.toList $ Map.restrictKeys packagesDB dependencies
+
+--   case packagesToList of
+--     [] -> logWarn "There are no dependencies listed in your spago.dhall"
+--     _ -> traverse_ output $ formatPackageNames jsonFlag packagesToList

--- a/spaghetto/src/Spago/Command/Ls.purs
+++ b/spaghetto/src/Spago/Command/Ls.purs
@@ -1,19 +1,18 @@
 module Spago.Command.Ls (listPackages, listPackageSet, LsEnv(..), JsonFlag(..), IncludeTransitive(..)) where
 
-import Data.String.CodeUnits
 import Spago.Prelude
 
 import Data.Array (replicate)
-import Data.Foldable (maximum)
+import Data.String.CodeUnits (fromCharArray, length)
+import Data.Foldable (elem, maximum)
+import Data.Map (filterKeys)
 import Data.Map as Map
-import Data.Traversable (traverse_)
-import Data.Tuple.Nested (type (/\), (/\))
-import Registry.Types (PackageName(..))
-import Registry.Version as Version
+import Data.Set (unions)
+import Data.Tuple.Nested (type (/\))
 import Registry.PackageName as PackageName
-import Spago.Command.Build (BuildEnv)
-import Spago.Command.Registry (RegistryEnv)
-import Spago.Config (Package(..), PackageSet(..), getPackageLocation)
+import Registry.Version as Version
+import Spago.Config (Dependencies(..), Package(..), PackageSet, Workspace, getPackageLocation)
+import Spago.Config as Config
 
 data IncludeTransitive = IncludeTransitive | NoIncludeTransitive
 data JsonFlag = JsonOutputNo | JsonOutputYes
@@ -21,6 +20,7 @@ data JsonFlag = JsonOutputNo | JsonOutputYes
 type LsEnv =
   { dependencies :: PackageSet
   , logOptions :: LogOptions
+  , workspace :: Workspace
   }
 
 data JsonPackageOutput = JsonPackageOutput
@@ -39,27 +39,33 @@ data JsonPackageOutput = JsonPackageOutput
 -- encodeJsonPackageOutput :: JsonPackageOutput -> Text
 -- encodeJsonPackageOutput = LT.toStrict . LT.decodeUtf8 . Json.encode
 
+-- ls packages 300
+-- ls deps 30
+-- ls deps -t 72
+
 listPackageSet :: JsonFlag -> Spago LsEnv Unit
 listPackageSet jsonFlag = do
   logDebug "Running `listPackageSet`"
-  { dependencies: packagesDB } <- ask
-  output $ formatPackageNames jsonFlag (Map.toUnfoldable packagesDB)
-
--- let packagesToList = Map.toUnfoldable dependencies
--- case packagesToList of
---   -- [] -> logWarn "There are no dependencies listed in your spago.dhall"
---   [] -> pure unit
---   _ -> output $ OutputLines $ formatPackageNames jsonFlag packagesToList
+  { workspace } <- ask
+  output $ formatPackageNames jsonFlag (Map.toUnfoldable workspace.packageSet)
 
 listPackages :: IncludeTransitive -> JsonFlag -> Spago LsEnv Unit
-listPackages includeTransitive jsonFlag = do
+listPackages packagesFilter jsonFlag = do
   logDebug "Running `listPackages`"
-  { dependencies } <- ask
-  let packagesToList = Map.toUnfoldable dependencies
+  { dependencies, workspace } <- ask
+  let
+    packagesToList = Map.toUnfoldable case packagesFilter of
+      IncludeTransitive -> dependencies
+      NoIncludeTransitive ->
+        let
+          workspacePackages = Config.getWorkspacePackages workspace.packageSet
+          toDependencyNames (Dependencies deps) = Map.keys deps
+          directDependencies = unions $ ((toDependencyNames <<< _.dependencies <<< _.package) <$> workspacePackages)
+        in
+          filterKeys (\k -> k `elem` directDependencies) dependencies
   case packagesToList of
-    -- [] -> logWarn "There are no dependencies listed in your spago.dhall"
-    [] -> pure unit
-    _ -> output $ formatPackageNames jsonFlag []
+    [] -> logWarn "There are no dependencies listed in your spago.dhall"
+    _ -> output $ formatPackageNames jsonFlag packagesToList
 
 formatPackageNames :: forall a. JsonFlag -> Array (PackageName /\ Package) -> OutputFormat a
 formatPackageNames = case _ of
@@ -68,7 +74,7 @@ formatPackageNames = case _ of
   where
   -- | Format all the packages from the config in JSON
   formatPackageNamesJson :: Array (PackageName /\ Package) -> Array String
-  formatPackageNamesJson pkgs = []
+  formatPackageNamesJson _pkgs = []
 
   -- let
   --   asJson (packageName /\ (Package { location: loc@(Remote { repo, version }) })) = JsonPackageOutput
@@ -84,12 +90,6 @@ formatPackageNames = case _ of
   -- in
   --   map (encodeJsonPackageOutput.asJson) pkgs
 
-  -- data Package
-  --   = RegistryVersion Version
-  --   | GitPackage GitPackage
-  --   | LocalPackage LocalPackage
-  --   | WorkspacePackage WorkspacePackage
-
   -- | Format all the package names from the configuration
   formatPackageNamesText :: Array (PackageName /\ Package) -> Array String
   formatPackageNamesText pkgs =
@@ -103,7 +103,8 @@ formatPackageNames = case _ of
       -- showLocation (Local { localPath }) = "Local " <> surroundQuote localPath
       -- TODO: Probably not what we want
       showLocation :: PackageName -> Package -> String
-      showLocation packageName package = getPackageLocation packageName package
+      showLocation _ (GitPackage gitPackage) = "Remote " <> surroundQuote gitPackage.git
+      showLocation packageName package = "Local " <> surroundQuote (getPackageLocation packageName package)
 
       longestName = fromMaybe 0 $ maximum $ (length <<< PackageName.print <<< fst) <$> pkgs
       longestVersion = fromMaybe 0 $ maximum $ (length <<< showVersion <<< snd) <$> pkgs
@@ -120,3 +121,6 @@ formatPackageNames = case _ of
   leftPad n s
     | length s < n = s <> (fromCharArray $ replicate (n - length s) ' ')
     | otherwise = s
+
+  surroundQuote :: String -> String
+  surroundQuote y = "\"" <> y <> "\""

--- a/spaghetto/src/Spago/Config.purs
+++ b/spaghetto/src/Spago/Config.purs
@@ -304,7 +304,7 @@ yamlDocCodec :: JsonCodec (YamlDoc Config)
 yamlDocCodec = CA.codec' decode encode
   where
   -- TODO: implementation of encode
-  encode _x = CA.encode CA.string "todo"
+  encode _x = CA.encode CA.null unit
 
   -- TODO: implementation of decode if needed
   decode _json = Left MissingValue
@@ -318,15 +318,13 @@ data Package
 packageCodec :: JsonCodec Package
 packageCodec = CA.codec' decode encode
   where
-  packageFromRegistryVersion = Version.codec
-
-  encode (RegistryVersion x) = CA.encode packageFromRegistryVersion x
-  encode (GitPackage u) = CA.encode gitPackageCodec u
-  encode (LocalPackage u) = CA.encode localPackageCodec u
-  encode (WorkspacePackage u) = CA.encode workspacePackageCodec u
+  encode (RegistryVersion x) = CA.encode Version.codec x
+  encode (GitPackage x) = CA.encode gitPackageCodec x
+  encode (LocalPackage x) = CA.encode localPackageCodec x
+  encode (WorkspacePackage x) = CA.encode workspacePackageCodec x
 
   decode json =
-    map RegistryVersion (CA.decode packageFromRegistryVersion json)
+    map RegistryVersion (CA.decode Version.codec json)
       <|> map GitPackage (CA.decode gitPackageCodec json)
       <|> map LocalPackage (CA.decode localPackageCodec json)
       <|> map WorkspacePackage (CA.decode workspacePackageCodec json)

--- a/spaghetto/src/Spago/Config.purs
+++ b/spaghetto/src/Spago/Config.purs
@@ -43,7 +43,6 @@ import Spago.Prelude
 import Affjax.Node as Http
 import Affjax.ResponseFormat as Response
 import Affjax.StatusCode (StatusCode(..))
-import Data.Argonaut.Core (Json)
 import Data.Array as Array
 import Data.Codec.Argonaut (JsonDecodeError(..))
 import Data.Codec.Argonaut as CA
@@ -319,19 +318,16 @@ data Package
 packageCodec :: JsonCodec Package
 packageCodec = CA.codec' decode encode
   where
-  packageFromRegistryVersion = CAR.object "RegistryVersion" { version: Version.codec }
-  packageFromGitPackage = gitPackageCodec
-  packageFromLocalPackage = localPackageCodec
-  packageFromWorkspacePackage = workspacePackageCodec
+  packageFromRegistryVersion = Version.codec
 
-  encode (RegistryVersion r) = CA.encode packageFromRegistryVersion { version: r }
-  encode (GitPackage u) = CA.encode packageFromGitPackage u
+  encode (RegistryVersion x) = CA.encode packageFromRegistryVersion x
+  encode (GitPackage u) = CA.encode gitPackageCodec u
   encode (LocalPackage u) = CA.encode localPackageCodec u
   encode (WorkspacePackage u) = CA.encode workspacePackageCodec u
 
   decode json =
-    map (RegistryVersion <<< _.version) (CA.decode packageFromRegistryVersion json)
-      <|> map GitPackage (CA.decode packageFromGitPackage json)
+    map RegistryVersion (CA.decode packageFromRegistryVersion json)
+      <|> map GitPackage (CA.decode gitPackageCodec json)
       <|> map LocalPackage (CA.decode localPackageCodec json)
       <|> map WorkspacePackage (CA.decode workspacePackageCodec json)
 

--- a/spaghetto/src/Spago/Config.purs
+++ b/spaghetto/src/Spago/Config.purs
@@ -25,6 +25,7 @@ module Spago.Config
   , addPackagesToConfig
   , addRangesToConfig
   , configCodec
+  , packageCodec
   , findPackageSet
   , getPackageLocation
   , getWorkspacePackages
@@ -42,7 +43,9 @@ import Spago.Prelude
 import Affjax.Node as Http
 import Affjax.ResponseFormat as Response
 import Affjax.StatusCode (StatusCode(..))
+import Data.Argonaut.Core (Json)
 import Data.Array as Array
+import Data.Codec.Argonaut (JsonDecodeError(..))
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Record as CAR
 import Data.Codec.Argonaut.Sum as CA.Sum
@@ -290,11 +293,47 @@ type WorkspacePackage =
   , hasTests :: Boolean
   }
 
+workspacePackageCodec :: JsonCodec WorkspacePackage
+workspacePackageCodec = CAR.object "WorkspacePackage"
+  { path: CA.string
+  , package: packageConfigCodec
+  , doc: yamlDocCodec
+  , hasTests: CA.boolean
+  }
+
+yamlDocCodec :: JsonCodec (YamlDoc Config)
+yamlDocCodec = CA.codec' decode encode
+  where
+  -- TODO: implementation of encode
+  encode _x = CA.encode CA.string "todo"
+
+  -- TODO: implementation of decode if needed
+  decode _json = Left MissingValue
+
 data Package
   = RegistryVersion Version
   | GitPackage GitPackage
   | LocalPackage LocalPackage
   | WorkspacePackage WorkspacePackage
+
+packageCodec :: JsonCodec Package
+packageCodec = CA.codec' decode encode
+  where
+  packageFromRegistryVersion = CAR.object "RegistryVersion" { version: Version.codec }
+  packageFromGitPackage = gitPackageCodec
+  packageFromLocalPackage = localPackageCodec
+  packageFromWorkspacePackage = workspacePackageCodec
+
+  encode (RegistryVersion r) = CA.encode packageFromRegistryVersion { version: r }
+  encode (GitPackage u) = CA.encode packageFromGitPackage u
+  encode (LocalPackage u) = CA.encode localPackageCodec u
+  encode (WorkspacePackage u) = CA.encode workspacePackageCodec u
+
+  decode json =
+    map (RegistryVersion <<< _.version) (CA.decode packageFromRegistryVersion json)
+      <|> map GitPackage (CA.decode packageFromGitPackage json)
+      <|> map LocalPackage (CA.decode localPackageCodec json)
+      <|> map WorkspacePackage (CA.decode workspacePackageCodec json)
 
 type LocalPackage = { path :: FilePath }
 

--- a/spaghetto/src/Spago/Log.purs
+++ b/spaghetto/src/Spago/Log.purs
@@ -23,13 +23,19 @@ import Prelude
 
 import Control.Monad.Reader (class MonadAsk)
 import Control.Monad.Reader as Reader
+import Data.Array ((:))
+import Data.Array as Array
 import Data.Codec.Argonaut (JsonCodec)
+import Data.Maybe (fromMaybe)
 import Data.String as String
-import Dodo (Doc)
+import Dodo (Doc, print, twoSpaces)
 import Dodo (indent, break) as DodoExport
+import Dodo as Dodo
 import Dodo as Log
 import Dodo.Ansi (GraphicsParam)
 import Dodo.Ansi as Ansi
+import Dodo.Box (DocBox)
+import Dodo.Box as Box
 import Effect (Effect)
 import Effect.Class (class MonadEffect)
 import Effect.Class as Effect
@@ -123,14 +129,76 @@ data OutputFormat a
   | OutputTable { titles :: Array String, rows :: Array (Array String) }
   | OutputLines (Array String)
 
+foreign import supportsColor :: Effect Boolean
+
+indent2 :: forall a. Doc a -> Doc a
+indent2 = Log.indent <<< Log.indent
+
 output :: forall a m. MonadEffect m => OutputFormat a -> m Unit
 output format = Console.log case format of
   OutputJson codec json -> Json.printJson codec json
   OutputLines lines -> String.joinWith "\n" lines
   -- https://github.com/natefaubion/purescript-dodo-printer/blob/master/test/snapshots/DodoBox.purs
-  OutputTable { titles, rows } -> "TODO: Unimplemented"
+  OutputTable { titles, rows } ->
+    Log.print Log.plainText (Log.twoSpaces)
+      $ Box.toDoc
+      $ logTable { headers: textBox <$> titles, rows: (map textBox) <$> rows }
 
-foreign import supportsColor :: Effect Boolean
+textBox :: forall a. String -> DocBox a
+textBox = print Box.docBox twoSpaces <<< Dodo.text
 
-indent2 :: forall a. Doc a -> Doc a
-indent2 = Log.indent <<< Log.indent
+-- TODO: Change visual appearance
+logTable
+  :: forall a
+   . { headers :: Array (DocBox a), rows :: Array (Array (DocBox a)) }
+  -> DocBox a
+logTable { headers, rows } =
+  Box.vertical
+    [ rowSep
+    , Box.vertical $ columns headers : rowSep : (columns <$> rows)
+    , rowSep
+    ]
+  where
+  joint = Box.fill (Log.text "+") { width: 1, height: 1 }
+
+  rowSep =
+    Box.horizontal
+      [ joint
+      , Box.horizontal
+          $ Array.intersperse joint
+          $ map (\width -> Box.fill (Dodo.text "-") { width: width + 2, height: 1 }) widths
+      , joint
+      ]
+
+  columns cols = do
+    let
+      height = Array.foldr (max <<< _.height <<< Box.sizeOf) 0 cols
+      sep = Box.fill (Dodo.text "|") { width: 1, height }
+      colBoxes = Array.mapWithIndex
+        ( \ix col ->
+            Box.horizontal
+              [ Box.hpadding 1
+              , Box.resize { width: fromMaybe 0 (Array.index widths ix), height } col
+              , Box.hpadding 1
+              ]
+        )
+        cols
+
+    Box.horizontal
+      [ sep
+      , Box.horizontal $ Array.intersperse sep colBoxes
+      , sep
+      ]
+
+  widths = Array.mapWithIndex
+    ( \ix hd ->
+        Array.foldr
+          ( flip Array.index ix
+              >>> map (_.width <<< Box.sizeOf)
+              >>> fromMaybe 0
+              >>> max
+          )
+          (Box.sizeOf hd).width
+          rows
+    )
+    headers


### PR DESCRIPTION
### Description of the change

The draft is supposed to replicate existing behavior of spago in spago@next. In particular `ls deps` and `ls packages` with the flags `-t` and `-j`.

The behavior is not there yet. This is a draft to get help for some of the open questions, marked as comments.

