### PR TITLE
Pass on files and excludeFiles from config to registry

### DIFF
--- a/spaghetto/README.md
+++ b/spaghetto/README.md
@@ -289,6 +289,12 @@ package:
     location:
       githubOwner: owner
       githubRepo: repo
+    # optional, globs of additional files to publish
+    files:
+      - "src-extra/**/*.purs"
+    # optional, globs of files to exclude from publishing
+    excludeFiles:
+      - "src/**/*Test.purs"
 
 # Optional
 workspace:

--- a/spaghetto/core/src/Config.purs
+++ b/spaghetto/core/src/Config.purs
@@ -161,6 +161,8 @@ bundleConfigCodec = CAR.object "BundleConfig"
 
 data BundlePlatform = BundleNode | BundleBrowser
 
+derive instance Eq BundlePlatform
+
 instance Show BundlePlatform where
   show = case _ of
     BundleNode -> "node"
@@ -178,6 +180,8 @@ bundlePlatformCodec = CA.Sum.enumSum show (parsePlatform)
 -- | This is the equivalent of "WithMain" in the old Spago.
 -- App bundles with a main fn, while Module does not include a main.
 data BundleType = BundleApp | BundleModule
+
+derive instance Eq BundleType
 
 instance Show BundleType where
   show = case _ of
@@ -364,6 +368,8 @@ instance Show StatVerbosity where
     NoStats -> "NoStats"
     CompactStats -> "CompactStats"
     VerboseStats -> "VerboseStats"
+
+derive instance Eq StatVerbosity
 
 statVerbosityCodec :: JsonCodec StatVerbosity
 statVerbosityCodec = CA.Sum.enumSum print parse

--- a/spaghetto/core/src/Config.purs
+++ b/spaghetto/core/src/Config.purs
@@ -94,6 +94,8 @@ type PublishConfig =
   { version :: Version
   , license :: License
   , location :: Maybe Location
+  , files :: Maybe (Array String)
+  , excludeFiles :: Maybe (Array String)
   }
 
 publishConfigCodec :: JsonCodec PublishConfig
@@ -101,6 +103,8 @@ publishConfigCodec = CAR.object "PublishConfig"
   { version: Version.codec
   , license: License.codec
   , location: CAR.optional Location.codec
+  , files: CAR.optional (CA.array CA.string)
+  , excludeFiles: CAR.optional (CA.array CA.string)
   }
 
 type RunConfig =

--- a/spaghetto/spago.lock
+++ b/spaghetto/spago.lock
@@ -109,8 +109,8 @@ workspace:
       ref: 68dddd9351f256980454bc2c1d0aea20e4d53fa9
       subdir: foreign
     registry-lib:
-      git: https://github.com/purescript/registry-dev.git
-      ref: 68dddd9351f256980454bc2c1d0aea20e4d53fa9
+      git: https://github.com/i-am-the-slime/registry-dev.git
+      ref: 5c81d2f75bd3abe404d4e9e9bb85945758572f22
       subdir: lib
 packages:
   aff:
@@ -679,6 +679,40 @@ packages:
     dependencies:
       - functions
       - maybe
+  language-cst-parser:
+    type: registry
+    version: 0.12.3
+    integrity: sha256-0pnjIJMtW9u1ne+fKB4QbaCeqqwWIGE3fjEQOIU0+ks=
+    dependencies:
+      - arrays
+      - console
+      - const
+      - control
+      - effect
+      - either
+      - enums
+      - foldable-traversable
+      - free
+      - functions
+      - functors
+      - identity
+      - integers
+      - lazy
+      - lists
+      - maybe
+      - newtype
+      - node-process
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - st
+      - strings
+      - transformers
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+      - unsafe-coerce
   lazy:
     type: registry
     version: 6.0.0
@@ -1119,8 +1153,8 @@ packages:
       - variant
   registry-lib:
     type: git
-    url: https://github.com/purescript/registry-dev.git
-    rev: 68dddd9351f256980454bc2c1d0aea20e4d53fa9
+    url: https://github.com/i-am-the-slime/registry-dev.git
+    rev: 5c81d2f75bd3abe404d4e9e9bb85945758572f22
     subdir: lib
     dependencies:
       - aff
@@ -1139,6 +1173,7 @@ packages:
       - functors
       - graphs
       - integers
+      - language-cst-parser
       - lists
       - maybe
       - newtype

--- a/spaghetto/spago.yaml
+++ b/spaghetto/spago.yaml
@@ -57,8 +57,8 @@ workspace:
     registry: 20.0.1
   extra_packages:
     registry-lib:
-      git: https://github.com/purescript/registry-dev.git
-      ref: 68dddd9351f256980454bc2c1d0aea20e4d53fa9
+      git: https://github.com/i-am-the-slime/registry-dev.git
+      ref: 5c81d2f75bd3abe404d4e9e9bb85945758572f22
       subdir: lib
     registry-foreign:
       git: https://github.com/purescript/registry-dev.git

--- a/spaghetto/test/Spago.purs
+++ b/spaghetto/test/Spago.purs
@@ -8,8 +8,10 @@ import Test.Spago.Lock as Lock
 import Test.Spec as Spec
 import Test.Spec.Reporter as Spec.Reporter
 import Test.Spec.Runner as Spec.Runner
+import Test.Spago.Config (spec) as Config
 
 main :: Effect Unit
 main = Aff.launchAff_ $ Spec.Runner.runSpec [ Spec.Reporter.consoleReporter ] do
-  Spec.describe "Spago"
+  Spec.describe "Spago" do
     Lock.spec
+    Config.spec

--- a/spaghetto/test/Spago/Config.purs
+++ b/spaghetto/test/Spago/Config.purs
@@ -1,0 +1,72 @@
+module Test.Spago.Config where
+
+import Spago.Prelude
+
+import Data.Codec.Argonaut as CA
+import Data.Map as Map
+import Registry.PackageName as PackageName
+import Registry.Version as Version
+import Registry.License as License
+import Spago.Core.Config (Dependencies(..))
+import Spago.Core.Config (Config, configCodec) as Config
+import Test.Spec (Spec)
+import Test.Spec as Spec
+import Test.Spec.Assertions as Assert
+import Registry.Location (Location(..))
+
+spec :: Spec Unit
+spec = do
+  Spec.it "Parses config" do
+    case parseYaml Config.configCodec validSpagoYAML of
+      Left error ->
+        Assert.fail $ "Failed to parse: " <> CA.printJsonDecodeError error
+      Right config | config /= validConfig ->
+        Assert.fail ("\n" <> printYaml Config.configCodec config <> "\ndoes not equal\n\n" <> printYaml Config.configCodec validConfig)
+      Right _ ->
+        pure unit
+
+validConfig :: Config.Config
+validConfig =
+  { package: Just
+      { name
+      , description: Nothing
+      , dependencies: Dependencies (Map.fromFoldable (dependency <$> [ "aff", "affjax" ]))
+      , bundle: Nothing
+      , run: Nothing
+      , test: Nothing
+      , publish: Just
+        { license
+        , version
+        , excludeFiles: Just [ "src/**/*Test.purs" ]
+        , files: Just [ "src-extra/**/*.purs" ]
+        , location: Just $ GitHub { owner: "purescript" , repo: "spago" , subdir: Nothing }
+        }
+      }
+      , workspace: Nothing
+  }
+  where
+  license = unsafeFromRight (License.parse "BSD-3-Clause")
+  version = unsafeFromRight (Version.parse "0.93.6")
+  name :: PackageName
+  name = unsafeFromRight (PackageName.parse "mypackage")
+  dependency name = Tuple (unsafeFromRight (PackageName.parse  name)) Nothing
+
+validSpagoYAML :: String
+validSpagoYAML =
+  """
+package:
+  name: mypackage
+  publish:
+    version: 0.93.6
+    license: BSD-3-Clause
+    location:
+      githubOwner: purescript
+      githubRepo: spago
+    files:
+      - "src-extra/**/*.purs"
+    excludeFiles:
+      - "src/**/*Test.purs"
+  dependencies:
+    - aff
+    - affjax
+  """


### PR DESCRIPTION
### Add `files` to config and enable colocation by adding `excludeFiles`, too

Adds `files` and `excludeFiles` to the publish config.
Those are then passed to the registry.

This is required for https://github.com/purescript/registry-dev/issues/602 

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

