### PR TITLE
spaghetto: descriptive error if esbuild is missing

### DIFF
--- a/spaghetto/bin/src/Main.purs
+++ b/spaghetto/bin/src/Main.purs
@@ -40,6 +40,7 @@ import Spago.Config as Config
 import Spago.Core.Config as Core
 import Spago.FS as FS
 import Spago.Git as Git
+import Spago.Esbuild as Esbuild
 import Spago.Json as Json
 import Spago.Log (LogVerbosity(..))
 import Spago.Paths as Paths
@@ -616,7 +617,8 @@ mkBundleEnv bundleArgs = do
           , pedanticPackages = bundleArgs.pedanticPackages || workspace.buildOptions.pedanticPackages
           }
       }
-  let bundleEnv = { esbuild: "esbuild", logOptions, workspace: newWorkspace, selected, bundleOptions }
+  esbuild <- Esbuild.getEsbuild
+  let bundleEnv = { esbuild, logOptions, workspace: newWorkspace, selected, bundleOptions }
   pure bundleEnv
 
 mkRunEnv :: forall a. RunArgs -> Spago (Fetch.FetchEnv a) (Run.RunEnv ())

--- a/spaghetto/src/Spago/Command/Bundle.purs
+++ b/spaghetto/src/Spago/Command/Bundle.purs
@@ -6,10 +6,11 @@ import Node.Path as Path
 import Data.String (Pattern(..), Replacement(..))
 import Data.String as String
 import Spago.Cmd as Cmd
+import Spago.Esbuild (Esbuild)
 import Spago.Config (BundlePlatform(..), BundleType(..), Workspace, WorkspacePackage)
 
 type BundleEnv a =
-  { esbuild :: FilePath
+  { esbuild :: Esbuild
   , logOptions :: LogOptions
   , bundleOptions :: BundleOptions
   , workspace :: Workspace
@@ -38,7 +39,6 @@ run = do
   { esbuild, selected, workspace, bundleOptions: opts } <- ask
   logDebug $ "Bundle options: " <> show opts
   let
-    command = esbuild
     minify = if opts.minify then [ "--minify" ] else []
     outfile = Path.concat [ selected.path, opts.outfile ]
     format = case opts.platform, opts.type of
@@ -71,7 +71,7 @@ run = do
       ] <> minify <> entrypoint <> nodePatch
   logInfo "Bundling..."
   logDebug $ "Running esbuild: " <> show args
-  Cmd.exec command args execOptions >>= case _ of
+  Cmd.exec esbuild.cmd args execOptions >>= case _ of
     Right _r -> logSuccess "Bundle succeeded."
     Left err -> do
       logDebug $ show err

--- a/spaghetto/src/Spago/Esbuild.purs
+++ b/spaghetto/src/Spago/Esbuild.purs
@@ -1,0 +1,18 @@
+module Spago.Esbuild (Esbuild, getEsbuild) where
+
+import Spago.Prelude
+
+import Spago.Cmd as Cmd
+
+type Esbuild =
+  { cmd :: FilePath
+  , version :: String 
+  }
+
+getEsbuild :: forall a. Spago (LogEnv a) Esbuild
+getEsbuild = 
+  Cmd.exec "esbuild" ["--version"] Cmd.defaultExecOptions { pipeStdout = false, pipeStderr = false } >>= case _ of
+    Left err -> do
+      logDebug $ show err
+      die [ "Failed to find esbuild. See https://esbuild.github.io/getting-started/#install-esbuild for ways to install esbuild." ] 
+    Right r -> pure { cmd: "esbuild", version: r.stdout }


### PR DESCRIPTION
### Description of the change

This fixes #946.
I used the [same implementation](https://github.com/purescript/spago/blob/243099f29ff5aec77ef236ee07f5213667cc0719/spaghetto/src/Spago/Purs.purs#L26-L31) for the `purs` command as guidance.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)
