### PR TITLE
Add include and exclude to publish config

### DIFF
--- a/spaghetto/core/src/Config.purs
+++ b/spaghetto/core/src/Config.purs
@@ -94,6 +94,8 @@ type PublishConfig =
   { version :: Version
   , license :: License
   , location :: Maybe Location
+  , include :: Maybe (Array FilePath)
+  , exclude :: Maybe (Array FilePath)
   }
 
 publishConfigCodec :: JsonCodec PublishConfig
@@ -101,6 +103,8 @@ publishConfigCodec = CAR.object "PublishConfig"
   { version: Version.codec
   , license: License.codec
   , location: CAR.optional Location.codec
+  , include: CAR.optional (CA.array CA.string)
+  , exclude: CAR.optional (CA.array CA.string)
   }
 
 type RunConfig =


### PR DESCRIPTION
This change adds config keys  
 -  `include` for specifying an array of globs matching files that shall be published in addition to the default (anything matching in `/src/**.purs`)
 -  `exclude` for finally specifying an array of globs to remove from the union of what's matched by the default and `include`

It's the first step to supporting this in the registry. Once this is merged, we'll add support and validation for this in the `registry-dev` repo and then finally finish with a PR to `spago/app`.

See #967 for discussion leading to this change.