### PR TITLE
spaghetto: nice error when Main module is missing

### DIFF
--- a/spaghetto/bin/src/Main.purs
+++ b/spaghetto/bin/src/Main.purs
@@ -562,7 +562,7 @@ main =
             buildEnv <- runSpago env (mkBuildEnv args dependencies)
             let options = { depsOnly: false, pursArgs: List.toUnfoldable args.pursArgs, jsonErrors: false }
             runSpago buildEnv (Build.run options)
-            runEnv <- runSpago env (mkRunEnv args)
+            runEnv <- runSpago env (mkRunEnv args dependencies)
             runSpago runEnv Run.run
           Test args@{ selectedPackage } -> do
             { env, fetchOpts } <- mkFetchEnv { packages: mempty, selectedPackage, ensureRanges: false }
@@ -648,12 +648,13 @@ mkBundleEnv bundleArgs = do
   let bundleEnv = { esbuild, logOptions, workspace: newWorkspace, selected, bundleOptions }
   pure bundleEnv
 
-mkRunEnv :: forall a. RunArgs -> Spago (Fetch.FetchEnv a) (Run.RunEnv ())
-mkRunEnv runArgs = do
+mkRunEnv :: forall a. RunArgs -> Map PackageName Package -> Spago (Fetch.FetchEnv a) (Run.RunEnv ())
+mkRunEnv runArgs dependencies = do
   { workspace, logOptions } <- ask
   logDebug $ "Run args: " <> show runArgs
 
   node <- Run.getNode
+  purs <- Purs.getPurs
 
   selected <- case workspace.selected of
     Just s -> pure s
@@ -691,7 +692,7 @@ mkRunEnv runArgs = do
       , failureMessage: "Running failed."
       }
   let newWorkspace = workspace { buildOptions { output = runArgs.output <|> workspace.buildOptions.output } }
-  let runEnv = { logOptions, workspace: newWorkspace, selected, node, runOptions }
+  let runEnv = { logOptions, workspace: newWorkspace, selected, node, runOptions, dependencies, purs }
   pure runEnv
 
 mkTestEnv :: forall a b. TestArgs -> Build.BuildEnv b -> Spago (Fetch.FetchEnv a) (Test.TestEnv ())

--- a/spaghetto/src/Spago/Command/Run.purs
+++ b/spaghetto/src/Spago/Command/Run.purs
@@ -11,20 +11,28 @@ import Spago.Prelude
 import Data.Array as Array
 import Data.String (Pattern(..), Replacement(..))
 import Data.String as String
+import Data.Map as Map
+import Data.Codec.Argonaut as CA
 import Node.FS.Perms as Perms
 import Node.Path as Path
 import Registry.Version as Version
 import Spago.Cmd as Cmd
-import Spago.Config (Workspace, WorkspacePackage)
+import Spago.Config (Package, Workspace, WorkspacePackage)
+import Spago.Config as Config
+import Spago.Purs (Purs, ModuleGraph(..))
+import Spago.Purs as Purs
 import Spago.FS as FS
 import Spago.Paths as Paths
+import Spago.Command.Build as Build
 
 type RunEnv a =
   { logOptions :: LogOptions
   , workspace :: Workspace
   , runOptions :: RunOptions
   , selected :: WorkspacePackage
+  , dependencies :: Map PackageName Package
   , node :: Node
+  , purs :: Purs
   | a
   }
 
@@ -88,6 +96,23 @@ run = do
             , "'\n\n"
             , "main()"
             ]
+      
+      dependencies <- _.dependencies <$> ask
+      let 
+        globs = Build.getBuildGlobs
+          { dependencies
+          , depsOnly: false
+          , withTests: true
+          , selected: case workspace.selected of
+              Just p -> [ p ]
+              -- TODO: this is safe because we check that the workspace is not empty wayy earlier
+              Nothing -> Config.getWorkspacePackages workspace.packageSet
+          }
+      Purs.graph globs [] >>= case _ of
+        Left err -> logWarn $ "Could not decode the output of `purs graph`, error: " <> CA.printJsonDecodeError err
+        Right (ModuleGraph graph) -> do
+          when (isNothing $ Map.lookup "Main" graph) do
+            die [ opts.failureMessage, "Module Main not found! Are you including it in your build?" ]
 
       logDebug $ "Writing " <> show runJsPath
       FS.writeTextFile runJsPath nodeContents

--- a/spaghetto/src/Spago/Command/Test.purs
+++ b/spaghetto/src/Spago/Command/Test.purs
@@ -46,7 +46,7 @@ run = do
         , moduleName
         }
 
-      runEnv = { logOptions, workspace, selected, node, runOptions }
+      runEnv = { logOptions, workspace, selected, node, runOptions, dependencies, purs }
 
     -- We check if the test module is included in the build and spit out a nice error if it isn't (see #383)
     let


### PR DESCRIPTION
### Description of the change

This fixes #940.

I used `Purs.graph` to check whether there is a Main module.
I am unsure if i got all values needed to run `Purs.graph` from the right places. In particular the `globs` argument, I copied the call to `getBuildGlobs` from [Command/Build](https://github.com/purescript/spago/blob/aa9773e3e5f6092fb45c9039554fe18a594e3b95/spaghetto/src/Spago/Command/Build.purs#L130C13-L130C26) along with its TODO.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

