### PR TITLE
fix `cabal build --enable-tests`, update Stack resolver, fix Spago on Nixpkgs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  STACK_VERSION: '2.9.1'
+  STACK_VERSION: '2.11.1'
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            image: haskell:9.2.4
+            image: haskell:9.2.8
           - os: macOS-latest
           - os: windows-latest
     steps:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -1,0 +1,75 @@
+# https://github.com/haskell/actions/tree/main/setup#model-cabal-workflow-with-caching
+name: Cabal build
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc-version: ['9.2']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell/actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        run: cabal build all --only-dependencies
+
+      - name: Fetch templates
+        run: ./scripts/fetch-templates
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # Caches are immutable, trying to save with the same key would error.
+        if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: cabal build all
+
+      - name: Run tests
+        run: cabal test all
+
+      - name: Check cabal file
+        run: cabal check
+
+      - name: Build documentation
+        run: cabal haddock all

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -65,13 +65,14 @@ jobs:
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Build
-        run: cabal build all
+        run: cabal build all --enable-tests
 
-      - name: Run tests
-        run: cabal test all
+      # run tests in Stack GitHub Action
+      # - name: Run tests
+      #   run: cabal test all
 
-      - name: Check cabal file
-        run: cabal check
+      # - name: Check cabal file
+      #   run: cabal check
 
-      - name: Build documentation
-        run: cabal haddock all
+      # - name: Build documentation
+      #   run: cabal haddock all

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -48,7 +48,9 @@ jobs:
           restore-keys: ${{ env.key }}-
 
       - name: Install dependencies
-        run: cabal build all --only-dependencies
+        run: |
+          cabal build all --only-dependencies
+          npm install -g purescript@0.15.8 psc-package@3.0.1 bower@1.8.8 esbuild@0.14.28
 
       - name: Fetch templates
         run: ./scripts/fetch-templates

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ stack.yaml.lock
 !npm/.npmrc
 **/.vscode
 .psc*
+dist-newstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Other improvements:
+- builds with Cabal successfully
+
 ## [0.21.0] - 2023-05-04
 
 Features:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm](https://img.shields.io/npm/v/spago.svg)][spago-npm]
 [![Latest release](https://img.shields.io/github/v/release/purescript/spago.svg)](https://github.com/purescript/spago/releases)
 [![build](https://github.com/purescript/spago/actions/workflows/build.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/build.yml)
+[![Cabal build](https://github.com/purescript/spago/actions/workflows/cabal.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/cabal.yml)
 [![Build status](https://ci.appveyor.com/api/projects/status/jydvr4sur6j6816e/branch/master?svg=true)](https://ci.appveyor.com/project/f-f/spago/branch/master)
 [![Maintainer: f-f](https://img.shields.io/badge/maintainer-f%2d-f-teal.svg)](http://github.com/f-f)
 

--- a/spago.cabal
+++ b/spago.cabal
@@ -135,7 +135,7 @@ library
     , file-embed
     , filepath
     , foldl
-    , fsnotify
+    , fsnotify > 0.4.0.0
     , generic-lens
     , http-client
     , http-conduit
@@ -166,7 +166,7 @@ library
     , unordered-containers
     , uri-encode
     , utf8-string
-    , versions
+    , versions == 5.*
     , with-utf8
     , yaml
     , zlib
@@ -216,7 +216,7 @@ test-suite spec
     , temporary
     , text <1.3
     , turtle
-    , versions
+    , versions == 5.*
   build-tool-depends:
       hspec-discover:hspec-discover == 2.*
     -- we need the the executable available for the end to end tests

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -1,4 +1,4 @@
-{-# LaNgUaGe OverloadedLists #-}
+{-# LANGUAGE OverloadedLists #-}
 module Spago.Version
   ( VersionBump(..)
   , DryRun(..)

--- a/src/Spago/Watch.hs
+++ b/src/Spago/Watch.hs
@@ -30,7 +30,7 @@ watch
   => Set.Set Glob.Pattern -> ClearScreen -> AllowIgnored -> RIO env ()
   -> RIO env ()
 watch globs shouldClear allowIgnored action = do
-  let config = Watch.defaultConfig { Watch.confDebounce = Watch.NoDebounce }
+  let config = Watch.defaultConfig
   fileWatchConf config shouldClear allowIgnored $ \getGlobs -> do
     getGlobs globs
     action

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,11 @@
-resolver: nightly-2022-11-03
+resolver: lts-20.26
 packages:
   - .
 extra-deps:
-  - Cabal-3.6.2.0
-  - process-1.6.13.1
-  - dhall-1.39.0
+  - Cabal-3.6.3.0
   - semver-range-0.2.8
-  - with-utf8-1.0.2.2
+  - fsnotify-0.4.1.0
+  - versions-5.0.5
 allow-newer: true
 nix:
   packages: [zlib]


### PR DESCRIPTION
### Description of the change

Closes: https://github.com/purescript/spago/issues/987

- Fix `cabal build --enable-tests`

- Tested with same GHC as in Stack resolver, 9.2

- Update Stack resolver to latest for GHC 9.2

- Basic GitHub Action for Cabal, copied from: https://github.com/haskell/actions/tree/main/setup#model-cabal-workflow-with-caching

- Fix compatibility with latest FSNotify (https://hackage.haskell.org/package/fsnotify-0.4.1.0/docs/System-FSNotify.html), which should fix Spago on Nixpkgs: https://github.com/NixOS/nixpkgs/issues/253198
  - debounce was removed from library: https://hackage.haskell.org/package/fsnotify-0.4.1.0/changelog

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
