### PR TITLE
update `versions` dependency to version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Other improvements:
 - builds with Cabal successfully
+- update to latest `versions` dependency: https://hackage.haskell.org/package/versions-6.0.1/changelog
 
 ## [0.21.0] - 2023-05-04
 

--- a/spago.cabal
+++ b/spago.cabal
@@ -166,7 +166,7 @@ library
     , unordered-containers
     , uri-encode
     , utf8-string
-    , versions == 5.*
+    , versions == 6.*
     , with-utf8
     , yaml
     , zlib
@@ -216,7 +216,7 @@ test-suite spec
     , temporary
     , text <1.3
     , turtle
-    , versions == 5.*
+    , versions == 6.*
   build-tool-depends:
       hspec-discover:hspec-discover == 2.*
     -- we need the the executable available for the end to end tests

--- a/src/Spago/Version.hs
+++ b/src/Spago/Version.hs
@@ -60,8 +60,9 @@ getCurrentVersion = do
 
   case Safe.maximumMay tags of
     Nothing -> do
-      logInfo $ display $ "No git version tags found, so assuming current version is " <> unparseVersion mempty
-      pure mempty
+      let currentVersion = SemVer 0 0 0 Nothing Nothing
+      logInfo $ display $ "No git version tags found, so assuming current version is " <> tshow currentVersion
+      pure currentVersion
     Just maxVersion -> do
       logInfo $ display $ "Found current version from git tag: " <> unparseVersion maxVersion
       pure maxVersion
@@ -70,9 +71,9 @@ getCurrentVersion = do
 getNextVersion :: VersionBump -> SemVer -> Either Text SemVer
 getNextVersion spec currentV@SemVer{..} =
   case spec of
-    Major -> Right $ SemVer (_svMajor + 1) 0 0 [] mempty
-    Minor -> Right $ SemVer _svMajor (_svMinor + 1) 0 [] mempty
-    Patch -> Right $ SemVer _svMajor _svMinor (_svPatch + 1) [] mempty
+    Major -> Right $ SemVer (_svMajor + 1) 0 0 Nothing mempty
+    Minor -> Right $ SemVer _svMajor (_svMinor + 1) 0 Nothing mempty
+    Patch -> Right $ SemVer _svMajor _svMinor (_svPatch + 1) Nothing mempty
     Exact newV
       | currentV < newV -> Right newV
       | otherwise -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
   - Cabal-3.6.3.0
   - semver-range-0.2.8
   - fsnotify-0.4.1.0
-  - versions-5.0.5
+  - versions-6.0.1
 allow-newer: true
 nix:
   packages: [zlib]

--- a/test/BumpVersionSpec.hs
+++ b/test/BumpVersionSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedLists #-}
 module BumpVersionSpec (spec) where
 
-import           Data.Versions         (SemVer (..), VUnit (..))
+import           Data.Versions         (SemVer (..), Release(Release), Chunk(Alphanum))
 import           Prelude               hiding (FilePath)
 import qualified System.IO.Temp        as Temp
 import           Test.Hspec            (Spec, around_, before_, describe, it, shouldBe,
@@ -61,7 +61,7 @@ setOverrides overrides = do
   commitAll
 
 randomSemVer :: Gen SemVer
-randomSemVer = SemVer <$> arbitrary <*> arbitrary <*> arbitrary <*> pure [] <*> pure Nothing
+randomSemVer = SemVer <$> arbitrary <*> arbitrary <*> arbitrary <*> pure Nothing <*> pure Nothing
 
 spec :: Spec
 spec = describe "spago bump-version" $ do
@@ -107,18 +107,18 @@ spec = describe "spago bump-version" $ do
         parseVersionBump "patch" `shouldBe` Just Patch
 
       it "should parse version starting with 'v'" $
-        parseVersionBump "v1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 [] Nothing))
+        parseVersionBump "v1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 Nothing Nothing))
 
       it "should parse version not starting with 'v'" $
-        parseVersionBump "1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 [] Nothing))
+        parseVersionBump "1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 Nothing Nothing))
 
       -- TODO is this desired behavior, or should we just drop ONE 'v'? I'd agree it's edge case, but still :-)
       it "should drop multiple 'v's from the beginning" $
-        parseVersionBump "vvvvvvvv1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 [] Nothing))
+        parseVersionBump "vvvvvvvv1.2.3" `shouldBe` Just (Exact (SemVer 1 2 3 Nothing Nothing))
 
       -- TODO should this work or should we strip these in parser implementation?
       it "should parse versions with PREREL and META tags" $
-        parseVersionBump "1.2.3-r1+git123" `shouldBe` Just (Exact (SemVer 1 2 3 [[Str "r", Digits 1]] (Just "git123")))
+        parseVersionBump "1.2.3-r1+git123" `shouldBe` Just (Exact (SemVer 1 2 3 (Just (Release (pure (Alphanum "r1")))) (Just "git123")))
 
       it "should not parse version which is not semantic" $ do
         parseVersionBump "" `shouldBe` Nothing


### PR DESCRIPTION
### Description of the change

Trying to fix Spago in Nixpkgs: https://github.com/NixOS/nixpkgs/issues/253198

Nixpkgs provides only `versions` version 6: https://search.nixos.org/packages?channel=unstable&show=haskellPackages.versions&from=0&size=50&sort=relevance&type=packages&query=versions


`versions` changelog: https://hackage.haskell.org/package/versions-6.0.1/changelog

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
