### PR TITLE
`aeson` lower bound

### DIFF
--- a/spago.cabal
+++ b/spago.cabal
@@ -120,7 +120,7 @@ library
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints
   build-depends:
       Glob
-    , aeson
+    , aeson >= 2
     , aeson-pretty
     , ansi-terminal
     , async-pool


### PR DESCRIPTION

### Description of the change

Set 

```
aeson >= 2
```

Tested with
```
cabal build --enable-tests
```

Build fails when `aeson < 2`



### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
