### PR TITLE
bump `text` lower bound, support GHC 9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            image: haskell:9.2.8
+            image: haskell:9.4.6
           - os: macOS-latest
           - os: windows-latest
     steps:

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.2']
+        ghc-version: ['9.2', '9.4']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            image: haskell:9.2.4
+            image: haskell:9.4.6
           - os: macOS-latest
           - os: windows-latest
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  .
+
+allow-newer:
+  aeson-better-errors:aeson

--- a/spago.cabal
+++ b/spago.cabal
@@ -158,7 +158,7 @@ library
     , tar
     , template-haskell
     , temporary
-    , text <1.3
+    , text >= 2
     , time
     , transformers
     , turtle
@@ -183,7 +183,7 @@ executable spago
       ansi-terminal
     , base >=4.7 && <5
     , spago
-    , text <1.3
+    , text >= 2
     , turtle
     , with-utf8
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -main-is Spago -optP-Wno-nonportable-include-path
@@ -214,7 +214,7 @@ test-suite spec
     , process
     , spago
     , temporary
-    , text <1.3
+    , text >= 2
     , turtle
     , versions == 6.*
   build-tool-depends:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
-resolver: lts-20.26
+resolver: lts-21.11
 packages:
   - .
 extra-deps:
-  - Cabal-3.6.3.0
   - semver-range-0.2.8
-  - fsnotify-0.4.1.0
-  - versions-6.0.1
+  - async-pool-0.9.2
+  - bower-json-1.1.0.0
+  - aeson-better-errors-0.9.1.1
 allow-newer: true
 nix:
   packages: [zlib]
@@ -13,8 +13,8 @@ flags:
   aeson-pretty:
     lib-only: true
   # This is so we don't depend on libtinfo
-  haskeline:
-    terminfo: false
-    examples: false
+  # haskeline:
+  #   terminfo: false
+  #   examples: false
   cryptonite:
     use_target_attributes: false


### PR DESCRIPTION
### Description of the change

- GHC 9.4
- bump Stack resolver
- bump `text` lower bound
  - succeeds: `cabal build all --constraint 'text >= 2.0' --enable-tests`
  - new Stack resolver has `text` 2.0: https://www.stackage.org/lts-21.11
  - removing the lower bound on `text` entirely would also be fine, but might as well keep it to stay consistent with the Stack resolver  


I have not run the entire test suite locally, let's see if it succeeds in CI

Bumping the lower bound on `text` is helping me to get Spago on NixPkgs building: https://github.com/NixOS/nixpkgs/issues/253198
It appears `text` 1.* is no longer available in NixPkgs: https://search.nixos.org/packages?channel=unstable&show=haskellPackages.text_2_0_2&from=0&size=50&sort=relevance&type=packages&query=haskell+text

Thanks
  
### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
