### PR TITLE
Add findFlags test; fix implementation

### DIFF
--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -10,6 +10,7 @@ import Effect.Aff (Milliseconds(..))
 import Effect.Aff as Aff
 import Test.Spago.Build as Build
 import Test.Spago.Bundle as Bundle
+import Test.Spago.FindFlags as FindFlags
 import Test.Spago.Init as Init
 import Test.Spago.Install as Install
 import Test.Spago.Lock as Lock
@@ -45,4 +46,5 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     Bundle.spec
     Spec.describe "miscellaneous" do
       Lock.spec
+      FindFlags.spec
 

--- a/test/Spago/FindFlags.purs
+++ b/test/Spago/FindFlags.purs
@@ -1,0 +1,32 @@
+module Test.Spago.FindFlags where
+
+import Prelude
+
+import Data.Maybe (fromMaybe)
+import Spago.Cmd as Cmd
+import Test.Spec (Spec, describe, describeOnly, it)
+import Test.Spec.Assertions (shouldEqual)
+
+spec :: Spec Unit
+spec = do
+  describeOnly "findFlag" $ do
+    it "[\"-o\", \"something\"]" $ do
+      let a = fromMaybe "" $ Cmd.findFlag { flags: [ "-o", "--output" ], args: [ "-o", "something" ] }
+      let b = "something"
+      a `shouldEqual` b
+    it "[\"--output\", \"something\"]" $ do
+      let a = fromMaybe "" $ Cmd.findFlag { flags: [ "-o", "--output" ], args: [ "--output", "something" ] }
+      let b = "something"
+      a `shouldEqual` b
+    it "[\"-o something\"]" $ do
+      let a = fromMaybe "" $ Cmd.findFlag { flags: [ "-o", "--output" ], args: [ "-o something" ] }
+      let b = "something"
+      a `shouldEqual` b
+    it "[\"--output something\"]" $ do
+      let a = fromMaybe "" $ Cmd.findFlag { flags: [ "-o", "--output" ], args: [ "--output something" ] }
+      let b = "something"
+      a `shouldEqual` b
+    it "[\"--output=something\"]" $ do
+      let a = fromMaybe "" $ Cmd.findFlag { flags: [ "-o", "--output" ], args: [ "--output=something" ] }
+      let b = "something"
+      a `shouldEqual` b


### PR DESCRIPTION
### Description of the change

Fixes #1006. After porting the tests, I got the following output:
```
spago » miscellaneous » findFlag
  ✓︎ ["-o", "something"]
  ✓︎ ["--output", "something"]
  ✗ ["-o something"]:

  "" ≠ "something"
  ✗ ["--output something"]:

  "" ≠ "something"
  ✓︎ ["--output=something"]
```

So, I reimplemented the code to fix the tests. Due to dropping the usage of `Array.uncons`, the new code should also be faster.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
