### PR TITLE
fix documentation for path to Test.Main in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ This last command will create a few files:
 ├── src
 │   └── Main.purs
 └── test
-    └── Main.purs
+    └── Test
+        └── Main.purs
 ```
 
 If you have a look at the `spago.yaml` file, you'll see that it contains two sections:


### PR DESCRIPTION
fixes: #1014

### Description of the change
I changed the path in the README.
previously: `test/Main.purs`
now: `test/Test/Main.purs`

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
