### PR TITLE
Docs command

### DIFF
--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -102,7 +102,7 @@ type BuildArgs a =
   | a
   }
 
-type DocsArgs = 
+type DocsArgs =
   { selectedPackage :: Maybe String
   , docsFormat :: Purs.DocsFormat
   , depsOnly :: Boolean
@@ -186,7 +186,7 @@ data Command a
   | Fetch FetchArgs
   | Install InstallArgs
   | Build (BuildArgs a)
-  | Docs DocsArgs 
+  | Docs DocsArgs
   | Bundle BundleArgs
   | Repl ReplArgs
   | Run RunArgs
@@ -395,20 +395,20 @@ docsArgsParser = Optparse.fromRecord
   -- , depsOnly: Flags.depsOnly
   , depsOnly: pure false :: Parser Boolean
   , docsFormat: parseFormat <$>
-     Maybe.optional
-       ( O.strOption
-         ( O.long "format"
-        <> O.short 'f'
-        <> O.metavar "FORMAT"
-        <> O.help "Docs output format (markdown | html | etags | ctags)"
-         )
-       )
+      Maybe.optional
+        ( O.strOption
+            ( O.long "format"
+                <> O.short 'f'
+                <> O.metavar "FORMAT"
+                <> O.help "Docs output format (markdown | html | etags | ctags)"
+            )
+        )
   }
   where
-    parseFormat :: Maybe String -> Purs.DocsFormat
-    parseFormat val = fromMaybe Purs.Html $ 
-      val >>= Purs.parseDocsFormat
-
+  parseFormat :: Maybe String -> Purs.DocsFormat
+  parseFormat val = fromMaybe Purs.Html
+    $ val
+    >>= Purs.parseDocsFormat
 
 registrySearchArgsParser :: Parser RegistrySearchArgs
 registrySearchArgsParser =
@@ -983,16 +983,14 @@ mkLsEnv dependencies = do
               ]
   pure { logOptions, workspace, dependencies, selected }
 
-
 mkDocsEnv :: forall a. DocsArgs -> Map PackageName Package -> Spago (Fetch.FetchEnv a) Docs.DocsEnv
 mkDocsEnv args dependencies = do
   { logOptions, workspace } <- ask
   purs <- Purs.getPurs
-  let env :: Docs.DocsEnv
-      env = { purs, logOptions, workspace, dependencies, depsOnly: args.depsOnly, docsFormat: args.docsFormat }
+  let
+    env :: Docs.DocsEnv
+    env = { purs, logOptions, workspace, dependencies, depsOnly: args.depsOnly, docsFormat: args.docsFormat }
   pure env
-
-
 
 shouldFetchRegistryRepos :: forall a. Spago (LogEnv a) Boolean
 shouldFetchRegistryRepos = do

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -28,6 +28,7 @@ import Spago.Bin.Flags as Flags
 import Spago.BuildInfo as BuildInfo
 import Spago.Command.Build as Build
 import Spago.Command.Bundle as Bundle
+import Spago.Command.Docs as Docs
 import Spago.Command.Fetch as Fetch
 import Spago.Command.Init as Init
 import Spago.Command.Ls (LsDepsArgs, LsPackagesArgs)
@@ -100,6 +101,8 @@ type BuildArgs a =
   , persistWarnings :: Maybe Boolean
   | a
   }
+
+type DocsArgs = { }
 
 -- TODO: more repl arguments: dependencies, repl-package
 type ReplArgs =
@@ -179,6 +182,7 @@ data Command a
   | Fetch FetchArgs
   | Install InstallArgs
   | Build (BuildArgs a)
+  | Docs DocsArgs 
   | Bundle BundleArgs
   | Repl ReplArgs
   | Run RunArgs
@@ -211,6 +215,8 @@ argParser =
     , commandParser "sources" (Sources <$> sourcesArgsParser) "List all the source paths (globs) for the dependencies of the project"
     , commandParser "repl" (Repl <$> replArgsParser) "Start a REPL"
     , commandParser "publish" (Publish <$> publishArgsParser) "Publish a package"
+
+    , commandParser "docs" (Docs <$> docsArgsParser) "Generate docs for the project and its dependencies"
     , O.command "registry"
         ( O.info
             ( O.hsubparser $ Foldable.fold
@@ -377,6 +383,10 @@ publishArgsParser =
   Optparse.fromRecord
     { selectedPackage: Flags.selectedPackage
     }
+
+docsArgsParser :: Parser DocsArgs
+docsArgsParser = Optparse.fromRecord { }
+
 
 registrySearchArgsParser :: Parser RegistrySearchArgs
 registrySearchArgsParser =
@@ -586,6 +596,10 @@ main =
             dependencies <- runSpago env (Fetch.run fetchOpts)
             lsEnv <- runSpago env (mkLsEnv dependencies)
             runSpago lsEnv (Ls.listPackages { json, transitive })
+
+          Docs _ -> do
+             logInfo "hello, world"
+
       Cmd'VersionCmd v -> do when v printVersion
   where
   printVersion = do

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -26,7 +26,6 @@ import Registry.ManifestIndex as ManifestIndex
 import Registry.Metadata as Metadata
 import Registry.PackageName as PackageName
 import Spago.Bin.Flags as Flags
-import Spago.BuildInfo as BuildInfo
 import Spago.Command.Build as Build
 import Spago.Command.Bundle as Bundle
 import Spago.Command.Docs as Docs
@@ -105,7 +104,8 @@ type BuildArgs a =
 
 type DocsArgs = 
   { selectedPackage :: Maybe String
-  
+  , docsFormat :: Purs.DocsFormat
+  , depsOnly :: Boolean
   }
 
 -- TODO: more repl arguments: dependencies, repl-package
@@ -391,11 +391,14 @@ publishArgsParser =
 docsArgsParser :: Parser DocsArgs
 docsArgsParser = Optparse.fromRecord
   { selectedPackage: Flags.selectedPackage
+  -- TODO: --deps-only
+  -- , depsOnly: Flags.depsOnly
+  , depsOnly: pure false :: Parser Boolean
   , docsFormat: parseFormat <$>
      Maybe.optional
        ( O.strOption
          ( O.long "format"
-        <> O.short "f"
+        <> O.short 'f'
         <> O.metavar "FORMAT"
         <> O.help "Docs output format (markdown | html | etags | ctags)"
          )
@@ -983,10 +986,10 @@ mkLsEnv dependencies = do
 
 mkDocsEnv :: forall a. DocsArgs -> Map PackageName Package -> Spago (Fetch.FetchEnv a) Docs.DocsEnv
 mkDocsEnv args dependencies = do
-  { purs, logOptions, workspace } <- ask
+  { logOptions, workspace } <- ask
   purs <- Purs.getPurs
   let env :: Docs.DocsEnv
-      env = { purs, logOptions, workspace, dependencies }
+      env = { purs, logOptions, workspace, dependencies, depsOnly: args.depsOnly, docsFormat: args.docsFormat }
   pure env
 
 

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -9,6 +9,7 @@ import Data.Foldable as Foldable
 import Data.JSDate as JSDate
 import Data.List as List
 import Data.Map as Map
+import Data.Maybe as Maybe
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.String as String
 import Effect.Aff as Aff
@@ -390,15 +391,21 @@ publishArgsParser =
 docsArgsParser :: Parser DocsArgs
 docsArgsParser = Optparse.fromRecord
   { selectedPackage: Flags.selectedPackage
-  , docsFormat: fromMaybe Docs.Html <$>
-     optional
-       ( strOption
-         ( long "docs-files"
-        <> metavar "GLOB"
-        <> help "Glob that captures `docs.json` files that should be used to build the index"
+  , docsFormat: parseFormat <$>
+     Maybe.optional
+       ( O.strOption
+         ( O.long "format"
+        <> O.short "f"
+        <> O.metavar "FORMAT"
+        <> O.help "Docs output format (markdown | html | etags | ctags)"
          )
        )
   }
+  where
+    parseFormat :: Maybe String -> Purs.DocsFormat
+    parseFormat val = fromMaybe Purs.Html $ 
+      val >>= Purs.parseDocsFormat
+
 
 registrySearchArgsParser :: Parser RegistrySearchArgs
 registrySearchArgsParser =

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -103,8 +103,7 @@ type BuildArgs a =
   }
 
 type DocsArgs =
-  { selectedPackage :: Maybe String
-  , docsFormat :: Purs.DocsFormat
+  { docsFormat :: Purs.DocsFormat
   , depsOnly :: Boolean
   }
 
@@ -390,10 +389,9 @@ publishArgsParser =
 
 docsArgsParser :: Parser DocsArgs
 docsArgsParser = Optparse.fromRecord
-  { selectedPackage: Flags.selectedPackage
   -- TODO: --deps-only
   -- , depsOnly: Flags.depsOnly
-  , depsOnly: pure false :: Parser Boolean
+  { depsOnly: pure false :: Parser Boolean
   , docsFormat: parseFormat <$>
       Maybe.optional
         ( O.strOption
@@ -618,8 +616,8 @@ main =
             dependencies <- runSpago env (Fetch.run fetchOpts)
             lsEnv <- runSpago env (mkLsEnv dependencies)
             runSpago lsEnv (Ls.listPackages { json, transitive })
-          Docs args@{ selectedPackage } -> do
-            { env, fetchOpts } <- mkFetchEnv { packages: mempty, selectedPackage, ensureRanges: false, testDeps: true }
+          Docs args -> do
+            { env, fetchOpts } <- mkFetchEnv { packages: mempty, selectedPackage: Nothing, ensureRanges: false, testDeps: true }
             -- TODO: --no-fetch flag
             dependencies <- runSpago env (Fetch.run fetchOpts)
             docsEnv <- runSpago env (mkDocsEnv args dependencies)

--- a/spago.lock
+++ b/spago.lock
@@ -172,28 +172,15 @@ workspace:
         - foldable-traversable
         - prelude
         - psci-support
-      git: https://github.com/klntsky/purescript-jest.git
-      ref: 7feaa5a880fc75002c4eca312993174e7220252b
-    literals:
-      dependencies:
-        - assert
-        - console
-        - effect
-        - integers
-        - numbers
-        - partial
-        - psci-support
-        - typelevel-prelude
-        - unsafe-coerce
-      git: https://github.com/jvliwanag/purescript-literals.git
-      ref: ae3ef4e9c1ae7c57ec77bd13906fa60ae8abba4a
+      git: https://github.com/nonbili/purescript-jest.git
+      ref: caf2032f2e5828337e897a99f5359c00e91cb0ee
     markdown-it:
       dependencies:
         - effect
         - options
         - prelude
-      git: https://github.com/klntsky/purescript-markdown-it.git
-      ref: f3b7654783a83a80d7c09b6caaa7cd40b93ddce1
+      git: https://github.com/nonbili/purescript-markdown-it.git
+      ref: f6e8ee91298f2fc13c4277e75a19e0538de5f7a2
     markdown-it-halogen:
       dependencies:
         - html-parser-halogen
@@ -230,44 +217,6 @@ workspace:
         - prelude
       git: https://github.com/klntsky/purescript-search-trie.git
       ref: e7f7f22486a1dba22171ec885dbc2149dc815119
-    string-parsers:
-      dependencies:
-        - arrays
-        - assert
-        - bifunctors
-        - console
-        - control
-        - effect
-        - either
-        - enums
-        - foldable-traversable
-        - lists
-        - maybe
-        - minibench
-        - nonempty
-        - partial
-        - prelude
-        - strings
-        - tailrec
-        - transformers
-        - unfoldable
-      git: https://github.com/purescript-contrib/purescript-string-parsers.git
-      ref: v8.0.0
-    untagged-union:
-      dependencies:
-        - assert
-        - console
-        - effect
-        - foreign
-        - foreign-object
-        - literals
-        - maybe
-        - newtype
-        - psci-support
-        - tuples
-        - unsafe-coerce
-      git: https://github.com/jvliwanag/purescript-untagged-union.git
-      ref: ed8262a966e15e751322c327e2759a9b9c0ef3f3
 packages:
   aff:
     type: registry
@@ -1109,8 +1058,8 @@ packages:
       - unfoldable
   markdown-it:
     type: git
-    url: https://github.com/klntsky/purescript-markdown-it.git
-    rev: f3b7654783a83a80d7c09b6caaa7cd40b93ddce1
+    url: https://github.com/nonbili/purescript-markdown-it.git
+    rev: f6e8ee91298f2fc13c4277e75a19e0538de5f7a2
     dependencies:
       - effect
       - options
@@ -1787,29 +1736,20 @@ packages:
       - tailrec
       - unsafe-coerce
   string-parsers:
-    type: git
-    url: https://github.com/purescript-contrib/purescript-string-parsers.git
-    rev: 518038cec5e76a1509bab87685e0dae77462d9e1
+    type: registry
+    version: 8.0.0
+    integrity: sha256-9ATYh0S54ERoR+uhkCM59wBRvW/6zv6geHJ0TmcI644=
     dependencies:
       - arrays
-      - assert
       - bifunctors
-      - console
       - control
-      - effect
       - either
-      - enums
       - foldable-traversable
       - lists
       - maybe
-      - minibench
-      - nonempty
-      - partial
       - prelude
       - strings
       - tailrec
-      - transformers
-      - unfoldable
   strings:
     type: registry
     version: 6.0.1

--- a/src/Spago/Command/Docs.purs
+++ b/src/Spago/Command/Docs.purs
@@ -1,8 +1,99 @@
-module Spago.Command.Docs where
+module Spago.Command.Docs
+  ( run
+  , DocsEnv
+  , OpenDocs(..)
+  , Search(..)
+  ) where
 
-import Prelude
-import Effect (Effect)
-import Docs.Search.Main (main)
+import Spago.Prelude
 
-doc :: Effect Unit
-doc = main
+import Control.Alternative as Alternative
+import Data.Array as Array
+import Data.Map as Map
+import Data.Set as Set
+import Data.Set.NonEmpty as NonEmptySet
+import Data.Tuple as Tuple
+import Docs.Search.IndexBuilder as IndexBuilder
+import Docs.Search.Main (defaultDocsFiles, defaultBowerFiles, defaultSourceFiles)
+import Docs.Search.Config (defaultPackageName)
+import Node.Process as Process
+import Registry.PackageName as PackageName
+import Spago.BuildInfo as BuildInfo
+import Spago.Cmd as Cmd
+import Spago.Command.Build (getBuildGlobs)
+import Spago.Config (Package(..), WithTestGlobs(..), Workspace, WorkspacePackage)
+import Spago.Config as Config
+import Spago.Git (Git)
+import Spago.Paths as Paths
+import Spago.Psa as Psa
+import Spago.Purs (Purs, DocsFormat(..))
+import Spago.Purs as Purs
+import Spago.Purs.Graph as Graph
+
+type DocsEnv =
+  { purs :: Purs
+  , workspace :: Workspace
+  , dependencies :: Map PackageName Package
+  , logOptions :: LogOptions
+  , docsFormat :: DocsFormat
+  , open :: OpenDocs
+  , search :: Search
+  , depsOnly :: Boolean
+  }
+
+-- | Flag to include search feature in generated html
+data Search = NoSearch | AddSearch
+
+derive instance Eq Search
+
+-- | Flag to open generated HTML documentation in browser
+data OpenDocs = NoOpenDocs | DoOpenDocs
+
+derive instance Eq OpenDocs
+
+run :: Spago DocsEnv Unit
+run = do
+  logDebug "Running `spago docs`"
+  logInfo "Generating documentation for the project. This might take a while..."
+  { workspace, dependencies, docsFormat, depsOnly, search, open } <- ask
+  let
+    globs = getBuildGlobs
+      { withTests: true
+      , selected:
+          case workspace.selected of
+            Just p -> [ p ]
+            Nothing -> Config.getWorkspacePackages workspace.packageSet
+      , dependencies
+      , depsOnly
+      }
+
+  _ <- Purs.docs globs docsFormat
+
+  when (docsFormat == Html) $ do
+    when (search == AddSearch) $ do
+      logInfo "Making the documentation searchable..."
+      liftAff $ IndexBuilder.run'
+        { noPatch: false
+        , generatedDocs: "./generatedDocs/"
+        , sourceFiles: defaultSourceFiles
+        , bowerFiles: defaultBowerFiles
+        , docsFiles: defaultDocsFiles
+        , packageName: defaultPackageName
+        }
+    
+    currentDir <- liftEffect Process.cwd
+    let link = "file://" <> currentDir <> "/generated-docs/html/index.html"
+    logInfo $ "Link: " <> link
+
+-- TODO: reimplement --open
+
+-- The haskell version used:
+-- https://github.com/rightfold/open-browser/tree/master
+
+-- The purescript version should probably FFI to a cross platform library such as:
+-- https://github.com/sindresorhus/open
+{-
+when (open == OpenDocs) $ do
+  logInfo "Opening in browser..."
+  open link
+-}

--- a/src/Spago/Command/Docs.purs
+++ b/src/Spago/Command/Docs.purs
@@ -37,7 +37,10 @@ run = do
       , depsOnly
       }
 
-  _ <- Purs.docs globs docsFormat
+  result <- Purs.docs globs docsFormat
+  case result of
+    Left err -> die err.message
+    Right _ -> pure unit
 
   when (docsFormat == Html) $ do
     currentDir <- liftEffect Process.cwd
@@ -51,4 +54,3 @@ run = do
 
 -- For purescript version looking at FFI to this library:
 -- https://github.com/sindresorhus/open
-

--- a/src/Spago/Command/Docs.purs
+++ b/src/Spago/Command/Docs.purs
@@ -1,34 +1,16 @@
 module Spago.Command.Docs
   ( run
   , DocsEnv
-  , OpenDocs(..)
-  , Search(..)
   ) where
 
 import Spago.Prelude
 
-import Control.Alternative as Alternative
-import Data.Array as Array
-import Data.Map as Map
-import Data.Set as Set
-import Data.Set.NonEmpty as NonEmptySet
-import Data.Tuple as Tuple
-import Docs.Search.IndexBuilder as IndexBuilder
-import Docs.Search.Main (defaultDocsFiles, defaultBowerFiles, defaultSourceFiles)
-import Docs.Search.Config (defaultPackageName)
 import Node.Process as Process
-import Registry.PackageName as PackageName
-import Spago.BuildInfo as BuildInfo
-import Spago.Cmd as Cmd
 import Spago.Command.Build (getBuildGlobs)
-import Spago.Config (Package(..), WithTestGlobs(..), Workspace, WorkspacePackage)
+import Spago.Config (Package, Workspace)
 import Spago.Config as Config
-import Spago.Git (Git)
-import Spago.Paths as Paths
-import Spago.Psa as Psa
 import Spago.Purs (Purs, DocsFormat(..))
 import Spago.Purs as Purs
-import Spago.Purs.Graph as Graph
 
 type DocsEnv =
   { purs :: Purs
@@ -36,26 +18,14 @@ type DocsEnv =
   , dependencies :: Map PackageName Package
   , logOptions :: LogOptions
   , docsFormat :: DocsFormat
-  , open :: OpenDocs
-  , search :: Search
   , depsOnly :: Boolean
   }
-
--- | Flag to include search feature in generated html
-data Search = NoSearch | AddSearch
-
-derive instance Eq Search
-
--- | Flag to open generated HTML documentation in browser
-data OpenDocs = NoOpenDocs | DoOpenDocs
-
-derive instance Eq OpenDocs
 
 run :: Spago DocsEnv Unit
 run = do
   logDebug "Running `spago docs`"
   logInfo "Generating documentation for the project. This might take a while..."
-  { workspace, dependencies, docsFormat, depsOnly, search, open } <- ask
+  { workspace, dependencies, docsFormat, depsOnly } <- ask
   let
     globs = getBuildGlobs
       { withTests: true
@@ -70,17 +40,6 @@ run = do
   _ <- Purs.docs globs docsFormat
 
   when (docsFormat == Html) $ do
-    when (search == AddSearch) $ do
-      logInfo "Making the documentation searchable..."
-      liftAff $ IndexBuilder.run'
-        { noPatch: false
-        , generatedDocs: "./generatedDocs/"
-        , sourceFiles: defaultSourceFiles
-        , bowerFiles: defaultBowerFiles
-        , docsFiles: defaultDocsFiles
-        , packageName: defaultPackageName
-        }
-    
     currentDir <- liftEffect Process.cwd
     let link = "file://" <> currentDir <> "/generated-docs/html/index.html"
     logInfo $ "Link: " <> link
@@ -90,10 +49,6 @@ run = do
 -- The haskell version used:
 -- https://github.com/rightfold/open-browser/tree/master
 
--- The purescript version should probably FFI to a cross platform library such as:
+-- For purescript version looking at FFI to this library:
 -- https://github.com/sindresorhus/open
-{-
-when (open == OpenDocs) $ do
-  logInfo "Opening in browser..."
-  open link
--}
+

--- a/src/Spago/Command/Docs.purs
+++ b/src/Spago/Command/Docs.purs
@@ -29,10 +29,7 @@ run = do
   let
     globs = getBuildGlobs
       { withTests: true
-      , selected:
-          case workspace.selected of
-            Just p -> [ p ]
-            Nothing -> Config.getWorkspacePackages workspace.packageSet
+      , selected: Config.getWorkspacePackages workspace.packageSet
       , dependencies
       , depsOnly
       }

--- a/src/Spago/Purs.purs
+++ b/src/Spago/Purs.purs
@@ -54,9 +54,42 @@ compile globs pursArgs = do
     { pipeStdout = false }
 
 repl :: forall a. Set FilePath -> Array String -> Spago (PursEnv a) (Either Cmd.ExecError Cmd.ExecResult)
+
 repl globs pursArgs = do
   { purs } <- ask
   let args = [ "repl" ] <> pursArgs <> Set.toUnfoldable globs
+  Cmd.exec purs.cmd args $ Cmd.defaultExecOptions
+    { pipeStdout = true
+    , pipeStderr = true
+    , pipeStdin = Cmd.StdinPipeParent
+    }
+
+data DocsFormat
+  = Html
+  | Markdown
+  | Ctags
+  | Etags
+derive instance Eq DocsFormat
+
+parseDocsFormat :: String -> Maybe DocsFormat
+parseDocsFormat = case _ of
+  "html"     -> Just Html
+  "markdown" -> Just Markdown
+  "ctags"    -> Just Ctags
+  "etags"    -> Just Etags
+  _          -> Nothing
+
+printDocsFormat :: DocsFormat -> String
+printDocsFormat = case _ of
+  Html     -> "html"
+  Markdown -> "markdown"
+  Ctags    -> "ctags"
+  Etags    -> "etags"
+
+docs :: forall a. Set FilePath -> DocsFormat -> Spago (PursEnv a) (Either Cmd.ExecError Cmd.ExecResult)
+docs globs format = do
+  { purs } <- ask
+  let args = [ "docs", "--format", printDocsFormat format ] <> Set.toUnfoldable globs
   Cmd.exec purs.cmd args $ Cmd.defaultExecOptions
     { pipeStdout = true
     , pipeStderr = true

--- a/src/Spago/Purs.purs
+++ b/src/Spago/Purs.purs
@@ -69,22 +69,23 @@ data DocsFormat
   | Markdown
   | Ctags
   | Etags
+
 derive instance Eq DocsFormat
 
 parseDocsFormat :: String -> Maybe DocsFormat
 parseDocsFormat = case _ of
-  "html"     -> Just Html
+  "html" -> Just Html
   "markdown" -> Just Markdown
-  "ctags"    -> Just Ctags
-  "etags"    -> Just Etags
-  _          -> Nothing
+  "ctags" -> Just Ctags
+  "etags" -> Just Etags
+  _ -> Nothing
 
 printDocsFormat :: DocsFormat -> String
 printDocsFormat = case _ of
-  Html     -> "html"
+  Html -> "html"
   Markdown -> "markdown"
-  Ctags    -> "ctags"
-  Etags    -> "etags"
+  Ctags -> "ctags"
+  Etags -> "etags"
 
 docs :: forall a. Set FilePath -> DocsFormat -> Spago (PursEnv a) (Either Cmd.ExecError Cmd.ExecResult)
 docs globs format = do

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -10,6 +10,7 @@ import Effect.Aff (Milliseconds(..))
 import Effect.Aff as Aff
 import Test.Spago.Build as Build
 import Test.Spago.Bundle as Bundle
+import Test.Spago.Docs as Docs
 import Test.Spago.Init as Init
 import Test.Spago.Install as Install
 import Test.Spago.Lock as Lock
@@ -44,6 +45,7 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     Run.spec
     Test.spec
     Bundle.spec
+    Docs.spec
     Spec.describe "miscellaneous" do
       Lock.spec
   Unit.spec

--- a/test/Spago/Docs.purs
+++ b/test/Spago/Docs.purs
@@ -1,0 +1,29 @@
+module Test.Spago.Docs where
+
+import Test.Prelude
+
+import Node.FS.Aff as FSA
+import Node.Path as Path
+import Registry.Version as Version
+import Spago.Command.Init as Init
+import Spago.Core.Config as Config
+import Spago.FS as FS
+import Test.Spec (Spec)
+import Test.Spec as Spec
+import Test.Spec.Assertions as Assert
+
+spec :: Spec Unit
+spec = Spec.around withTempDir do
+  Spec.describe "docs" do
+
+    Spec.it "documents successfully with no flags" \{ spago } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      spago [ "docs" ] >>= shouldBeSuccess
+
+    Spec.it "builds successfully a solver-only package" \{ spago } -> do
+      spago [ "init", "--name", "aaa", "--use-solver" ] >>= shouldBeSuccess
+      spago [ "docs" ] >>= shouldBeSuccess
+
+    Spec.it "can output ctags instead of html" \{ spago } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      spago [ "docs", "--format", "ctags" ] >>= shouldBeSuccess


### PR DESCRIPTION
### Description of the change

Reimplements the basic `spago docs` command.

Supports the `--format` flag, and the new `--package` flag, that the new spago commands use.
Otherwise the remaining Spago docs commands have not been ported yet.

Part of #1020

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

