### PR TITLE
Reintroduce source-map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,15 +871,15 @@ $ node -e "import('./index.js').then(m => console.log(m.main))"
 When bundling, you can include `--source-maps` to generate a final source map for your bundle.
 
 Example:
-```
+```console
 spago bundle -p my-project --source-maps --minify --outfile=bundle.js
 ```
 will generate a minified bundle: `bundle.js`, and a source map: `bundle.js.map`.
 
 #### Node
 If your target platform is node, then you need to ensure your node version is >= 12.2.0 and [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
-) when executing your bundle:
-```
+) when executing your script:
+```console
 spago bundle -p my-project --platform node --source-maps --minify --outfile=bundle.js
 node --enable-source-maps bundle.js
 ```
@@ -888,7 +888,7 @@ node --enable-source-maps bundle.js
 If you are targeting browsers, then you will need to ensure your server is configured to serve the source map from the same directory as your bundle.
 
 So for example if your server is configured to serve files from `public/`, you might run:
-```
+```console
 spago bundle -p my-project --platform browser --source-maps --minify --outfile=public/bundle.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -876,6 +876,14 @@ spago bundle -p my-project --source-maps --minify --outfile=bundle.js
 ```
 will generate a minified bundle: `bundle.js`, and a source map: `bundle.js.map`.
 
+If your target platform is 'node', then you need to [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
+) when executing your bundle:
+```
+node --enable-source-maps bundle.js
+```
+
+If your target platform is 'browser', then you will need to ensure your server is configured to serve the source map from the same directory as your bundle.
+
 ### Skipping the "build" step
 
 When running `spago bundle`, Spago will first try to `build` your project, since bundling requires the project to be compiled first.

--- a/README.md
+++ b/README.md
@@ -868,7 +868,6 @@ $ node -e "import('./index.js').then(m => console.log(m.main))"
 
 ### Enable source maps
 
-The `spago build` step generates source maps automatically.
 When bundling, you can include `--source-maps` to generate a final source map for your bundle.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -876,13 +876,21 @@ spago bundle -p my-project --source-maps --minify --outfile=bundle.js
 ```
 will generate a minified bundle: `bundle.js`, and a source map: `bundle.js.map`.
 
-If your target platform is 'node', then you need to ensure your node version is >= 12.2.0 and [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
+#### Node
+If your target platform is node, then you need to ensure your node version is >= 12.2.0 and [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
 ) when executing your bundle:
 ```
+spago bundle -p my-project --platform node --source-maps --minify --outfile=bundle.js
 node --enable-source-maps bundle.js
 ```
 
-If your target platform is 'browser', then you will need to ensure your server is configured to serve the source map from the same directory as your bundle.
+#### Browsers
+If you are targeting browsers, then you will need to ensure your server is configured to serve the source map from the same directory as your bundle.
+
+So for example if your server is configured to serve files from `public/`, then would run:
+```
+spago bundle -p my-project --platform browser --source-maps --minify --outfile=public/dist.js
+```
 
 ### Skipping the "build" step
 

--- a/README.md
+++ b/README.md
@@ -887,9 +887,9 @@ node --enable-source-maps bundle.js
 #### Browsers
 If you are targeting browsers, then you will need to ensure your server is configured to serve the source map from the same directory as your bundle.
 
-So for example if your server is configured to serve files from `public/`, then would run:
+So for example if your server is configured to serve files from `public/`, you might run:
 ```
-spago bundle -p my-project --platform browser --source-maps --minify --outfile=public/dist.js
+spago bundle -p my-project --platform browser --source-maps --minify --outfile=public/bundle.js
 ```
 
 ### Skipping the "build" step

--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ spago bundle -p my-project --source-maps --minify --outfile=bundle.js
 ```
 will generate a minified bundle: `bundle.js`, and a source map: `bundle.js.map`.
 
-If your target platform is 'node', then you need to [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
+If your target platform is 'node', then you need to ensure your node version is >= 12.2.0 and [enable source maps](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--enable-source-maps
 ) when executing your bundle:
 ```
 node --enable-source-maps bundle.js

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Where to go from here? There are a few places you should check out:
   - [Polyrepo support](#polyrepo-support)
   - [Test dependencies](#test-dependencies)
   - [Bundle a project into a single JS file](#bundle-a-project-into-a-single-js-file)
+  - [Enable source maps](#enable-source-maps)
   - [Skipping the "build" step](#skipping-the-build-step)
   - [Generated build info/metadata](#generated-build-infometadata)
   - [Generate documentation for my project](#generate-documentation-for-my-project)
@@ -864,6 +865,17 @@ Can now import it in your Node project:
 $ node -e "import('./index.js').then(m => console.log(m.main))"
 [Function]
 ```
+
+### Enable source maps
+
+The `spago build` step generates source maps automatically.
+When bundling, you can include `--source-maps` to generate a final source map for your bundle.
+
+Example:
+```
+spago bundle -p my-project --source-maps --minify --outfile=bundle.js
+```
+will generate a minified bundle: `bundle.js`, and a source map: `bundle.js.map`.
 
 ### Skipping the "build" step
 

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -306,3 +306,10 @@ ensureRanges =
     ( O.long "ensure-ranges"
         <> O.help "Add version bounds for all the dependencies of the selected project"
     )
+
+sourceMap :: Parser Boolean
+sourceMap =
+  O.switch
+    ( O.long "source-map"
+        <> O.help "Creates a source map for your bundle"
+    )

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -307,9 +307,9 @@ ensureRanges =
         <> O.help "Add version bounds for all the dependencies of the selected project"
     )
 
-sourceMap :: Parser Boolean
-sourceMap =
+sourceMaps :: Parser Boolean
+sourceMaps =
   O.switch
-    ( O.long "source-map"
+    ( O.long "source-maps"
         <> O.help "Creates a source map for your bundle"
     )

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -158,7 +158,7 @@ type SourcesArgs =
 
 type BundleArgs =
   { minify :: Boolean
-  , sourceMap :: Boolean
+  , sourceMaps :: Boolean
   , module :: Maybe String
   , outfile :: Maybe FilePath
   , platform :: Maybe String
@@ -368,7 +368,7 @@ bundleArgsParser :: Parser BundleArgs
 bundleArgsParser =
   Optparse.fromRecord
     { minify: Flags.minify
-    , sourceMap: Flags.sourceMap
+    , sourceMaps: Flags.sourceMaps
     , module: Flags.entrypoint
     , type: Flags.bundleType
     , outfile: Flags.outfile
@@ -679,7 +679,7 @@ mkBundleEnv bundleArgs = do
       ( (Config.parseBundleType =<< bundleArgs.type)
           <|> bundleConf _.type
       )
-  let bundleOptions = { minify, module: entrypoint, outfile, platform, type: bundleType, sourceMap: bundleArgs.sourceMap, extraArgs: fromMaybe [] (bundleConf _.extra_args) }
+  let bundleOptions = { minify, module: entrypoint, outfile, platform, type: bundleType, sourceMaps: bundleArgs.sourceMaps, extraArgs: fromMaybe [] (bundleConf _.extra_args) }
   let
     newWorkspace = workspace
       { buildOptions

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -158,6 +158,7 @@ type SourcesArgs =
 
 type BundleArgs =
   { minify :: Boolean
+  , sourceMap :: Boolean
   , module :: Maybe String
   , outfile :: Maybe FilePath
   , platform :: Maybe String
@@ -367,6 +368,7 @@ bundleArgsParser :: Parser BundleArgs
 bundleArgsParser =
   Optparse.fromRecord
     { minify: Flags.minify
+    , sourceMap: Flags.sourceMap
     , module: Flags.entrypoint
     , type: Flags.bundleType
     , outfile: Flags.outfile
@@ -677,7 +679,7 @@ mkBundleEnv bundleArgs = do
       ( (Config.parseBundleType =<< bundleArgs.type)
           <|> bundleConf _.type
       )
-  let bundleOptions = { minify, module: entrypoint, outfile, platform, type: bundleType, extraArgs: fromMaybe [] (bundleConf _.extra_args) }
+  let bundleOptions = { minify, module: entrypoint, outfile, platform, type: bundleType, sourceMap: bundleArgs.sourceMap, extraArgs: fromMaybe [] (bundleConf _.extra_args) }
   let
     newWorkspace = workspace
       { buildOptions

--- a/src/Spago/Command/Bundle.purs
+++ b/src/Spago/Command/Bundle.purs
@@ -18,7 +18,7 @@ type BundleEnv a =
 
 type BundleOptions =
   { minify :: Boolean
-  , sourceMap :: Boolean
+  , sourceMaps :: Boolean
   , module :: String
   , outfile :: FilePath
   , platform :: BundlePlatform
@@ -41,7 +41,7 @@ run = do
   logDebug $ "Bundle options: " <> show opts
   let
     minify = if opts.minify then [ "--minify" ] else []
-    sourceMap = if opts.sourceMap then [ "--sourcemap" ] else []
+    sourceMap = if opts.sourceMaps then [ "--sourcemap" ] else []
     outfile = Path.concat [ selected.path, opts.outfile ]
     format = case opts.platform, opts.type of
       BundleBrowser, BundleApp -> "--format=iife"

--- a/src/Spago/Command/Bundle.purs
+++ b/src/Spago/Command/Bundle.purs
@@ -18,6 +18,7 @@ type BundleEnv a =
 
 type BundleOptions =
   { minify :: Boolean
+  , sourceMap :: Boolean
   , module :: String
   , outfile :: FilePath
   , platform :: BundlePlatform
@@ -40,6 +41,7 @@ run = do
   logDebug $ "Bundle options: " <> show opts
   let
     minify = if opts.minify then [ "--minify" ] else []
+    sourceMap = if opts.sourceMap then [ "--sourcemap" ] else []
     outfile = Path.concat [ selected.path, opts.outfile ]
     format = case opts.platform, opts.type of
       BundleBrowser, BundleApp -> "--format=iife"
@@ -68,7 +70,7 @@ run = do
       -- See https://github.com/evanw/esbuild/issues/1051
       , "--loader:.node=file"
       , format
-      ] <> opts.extraArgs <> minify <> entrypoint <> nodePatch
+      ] <> opts.extraArgs <> minify <> sourceMap <> entrypoint <> nodePatch
   logInfo "Bundling..."
   logDebug $ "Running esbuild: " <> show args
   Cmd.exec esbuild.cmd args execOptions >>= case _ of

--- a/test-fixtures/bundle-app-map.js
+++ b/test-fixtures/bundle-app-map.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+(() => {
+  // output/Effect.Console/foreign.js
+  var log = function(s) {
+    return function() {
+      console.log(s);
+    };
+  };
+
+  // output/Main/index.js
+  var main = /* @__PURE__ */ log("\u{1F35D}");
+
+  // <stdin>
+  main();
+})();
+//# sourceMappingURL=bundle-app.js.map

--- a/test-fixtures/bundle-app-map.js
+++ b/test-fixtures/bundle-app-map.js
@@ -13,4 +13,4 @@
   // <stdin>
   main();
 })();
-//# sourceMappingURL=bundle-app.js.map
+//# sourceMappingURL=bundle-app-map.js.map

--- a/test-fixtures/bundle-app-map.js.map
+++ b/test-fixtures/bundle-app-map.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": ["output/Effect.Console/foreign.js", "src/Main.purs", "<stdin>"],
+  "sourcesContent": ["export const log = function (s) {\n  return function () {\n    console.log(s);\n  };\n};\n\nexport const warn = function (s) {\n  return function () {\n    console.warn(s);\n  };\n};\n\nexport const error = function (s) {\n  return function () {\n    console.error(s);\n  };\n};\n\nexport const info = function (s) {\n  return function () {\n    console.info(s);\n  };\n};\n\nexport const debug = function (s) {\n  return function () {\n    console.debug(s);\n  };\n};\n\nexport const time = function (s) {\n  return function () {\n    console.time(s);\n  };\n};\n\nexport const timeLog = function (s) {\n  return function () {\n    console.timeLog(s);\n  };\n};\n\nexport const timeEnd = function (s) {\n  return function () {\n    console.timeEnd(s);\n  };\n};\n\nexport const clear = function () {\n  console.clear();\n};\n", "module Main where\n\nimport Prelude\n\nimport Effect (Effect)\nimport Effect.Console (log)\n\nmain :: Effect Unit\nmain = do\n  log \"\uD83C\uDF5D\"\n\n", "#!/usr/bin/env node\n\nimport { main } from './output/Main/index.js'; main();"],
+  "mappings": ";;;AAAO,MAAM,MAAM,SAAU,GAAG;AAC9B,WAAO,WAAY;AACjB,cAAQ,IAAI,CAAC;AAAA,IACf;AAAA,EACF;;;ACGA,MAAA,OAAA,gBAAA,IAEM,WAAA;;;ACPyC,OAAK;",
+  "names": []
+}

--- a/test-fixtures/bundle-module-map.js
+++ b/test-fixtures/bundle-module-map.js
@@ -1,0 +1,13 @@
+// output/Effect.Console/foreign.js
+var log = function(s) {
+  return function() {
+    console.log(s);
+  };
+};
+
+// output/Main/index.js
+var main = /* @__PURE__ */ log("\u{1F35D}");
+export {
+  main
+};
+//# sourceMappingURL=bundle-module-map.js.map

--- a/test-fixtures/bundle-module-map.js.map
+++ b/test-fixtures/bundle-module-map.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": ["output/Effect.Console/foreign.js", "src/Main.purs"],
+  "sourcesContent": ["export const log = function (s) {\n  return function () {\n    console.log(s);\n  };\n};\n\nexport const warn = function (s) {\n  return function () {\n    console.warn(s);\n  };\n};\n\nexport const error = function (s) {\n  return function () {\n    console.error(s);\n  };\n};\n\nexport const info = function (s) {\n  return function () {\n    console.info(s);\n  };\n};\n\nexport const debug = function (s) {\n  return function () {\n    console.debug(s);\n  };\n};\n\nexport const time = function (s) {\n  return function () {\n    console.time(s);\n  };\n};\n\nexport const timeLog = function (s) {\n  return function () {\n    console.timeLog(s);\n  };\n};\n\nexport const timeEnd = function (s) {\n  return function () {\n    console.timeEnd(s);\n  };\n};\n\nexport const clear = function () {\n  console.clear();\n};\n", "module Main where\n\nimport Prelude\n\nimport Effect (Effect)\nimport Effect.Console (log)\n\nmain :: Effect Unit\nmain = do\n  log \"\uD83C\uDF5D\"\n\n"],
+  "mappings": ";AAAO,IAAM,MAAM,SAAU,GAAG;AAC9B,SAAO,WAAY;AACjB,YAAQ,IAAI,CAAC;AAAA,EACf;AACF;;;ACGA,IAAA,OAAA,gBAAA,IAEM,WAAA;",
+  "names": []
+}

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -37,7 +37,6 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     -- TODO:
     -- Upgrade set?
     -- Script?
-    {-
     Init.spec
     Sources.spec
     Install.spec
@@ -45,13 +44,10 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     Build.spec
     Run.spec
     Test.spec
-    -}
     Bundle.spec
-{-
-  Registry.spec
-  Docs.spec
-  Spec.describe "miscellaneous" do
-    Lock.spec
-Unit.spec
--}
+    Registry.spec
+    Docs.spec
+    Spec.describe "miscellaneous" do
+      Lock.spec
+  Unit.spec
 

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -37,7 +37,7 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     -- TODO:
     -- Upgrade set?
     -- Script?
-
+    {-
     Init.spec
     Sources.spec
     Install.spec
@@ -45,10 +45,13 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     Build.spec
     Run.spec
     Test.spec
+    -}
     Bundle.spec
-    Registry.spec
-    Docs.spec
-    Spec.describe "miscellaneous" do
-      Lock.spec
-  Unit.spec
+{-
+  Registry.spec
+  Docs.spec
+  Spec.describe "miscellaneous" do
+    Lock.spec
+Unit.spec
+-}
 

--- a/test/Spago/Bundle.purs
+++ b/test/Spago/Bundle.purs
@@ -25,15 +25,15 @@ spec = Spec.around withTempDir do
 
     Spec.it "bundles an app with source map" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
-      spago [ "bundle", "-v", "--outfile", fixture "bundle-app-map.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
-    -- checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
-    -- checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
+      spago [ "bundle", "-v", "--outfile", "bundle-app-map.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
+      checkFixture "bundle-app-map.js" (fixture "bundle-app-map.js")
+      checkFixture "bundle-app-map.js.map" (fixture "bundle-app-map.js.map")
 
     Spec.it "bundles a module with source map" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
       spago [ "build" ] >>= shouldBeSuccess
-      spago [ "bundle", "--bundle-type", "module", "--outfile", fixture "bundle-module-map.js", "--source-maps" ] >>= shouldBeSuccess
+      spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module-map.js", "--source-maps" ] >>= shouldBeSuccess
 
---checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
---checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
+      checkFixture "bundle-module-map.js" (fixture "bundle-module-map.js")
+      checkFixture "bundle-module-map.js.map" (fixture "bundle-module-map.js.map")
 

--- a/test/Spago/Bundle.purs
+++ b/test/Spago/Bundle.purs
@@ -23,16 +23,17 @@ spec = Spec.around withTempDir do
       spago [ "bundle", "--bundle-type=module", "--outfile", "bundle-module.js" ] >>= shouldBeSuccess
       checkFixture "bundle-module.js" (fixture "bundle-module.js")
 
-  Spec.it "bundles an app with source map" \{ spago, fixture } -> do
-    spago [ "init" ] >>= shouldBeSuccess
-    spago [ "bundle", "-v", "--outfile", "bundle-app.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
-    checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
-    checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
+    Spec.it "bundles an app with source map" \{ spago, fixture } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      spago [ "bundle", "-v", "--outfile", "bundle-app.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
+      checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
+      checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
 
-  Spec.it "bundles a module with source map" \{ spago, fixture } -> do
-    spago [ "init" ] >>= shouldBeSuccess
-    spago [ "build" ] >>= shouldBeSuccess
-    spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module.js", "--source-maps" ] >>= shouldBeSuccess
-    checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
-    checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
+    Spec.it "bundles a module with source map" \{ spago, fixture } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      spago [ "build" ] >>= shouldBeSuccess
+      spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module.js", "--source-maps" ] >>= shouldBeSuccess
+
+      checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
+      checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
 

--- a/test/Spago/Bundle.purs
+++ b/test/Spago/Bundle.purs
@@ -23,17 +23,16 @@ spec = Spec.around withTempDir do
       spago [ "bundle", "--bundle-type=module", "--outfile", "bundle-module.js" ] >>= shouldBeSuccess
       checkFixture "bundle-module.js" (fixture "bundle-module.js")
 
--- TODO: source maps
--- Spec.it "bundles an app with source map" \{ spago, fixture } -> do
---   spago [ "init" ] >>= shouldBeSuccess
---   spago [ "bundle", "-v", "--outfile", "bundle-app.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
---   checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
---   checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
+  Spec.it "bundles an app with source map" \{ spago, fixture } -> do
+    spago [ "init" ] >>= shouldBeSuccess
+    spago [ "bundle", "-v", "--outfile", "bundle-app.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
+    checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
+    checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
 
--- Spec.it "bundles a module with source map" \{ spago, fixture } -> do
---   spago [ "init" ] >>= shouldBeSuccess
---   spago [ "build" ] >>= shouldBeSuccess
---   spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module.js", "--source-maps" ] >>= shouldBeSuccess
---   checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
---   checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
+  Spec.it "bundles a module with source map" \{ spago, fixture } -> do
+    spago [ "init" ] >>= shouldBeSuccess
+    spago [ "build" ] >>= shouldBeSuccess
+    spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module.js", "--source-maps" ] >>= shouldBeSuccess
+    checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
+    checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
 

--- a/test/Spago/Bundle.purs
+++ b/test/Spago/Bundle.purs
@@ -25,15 +25,15 @@ spec = Spec.around withTempDir do
 
     Spec.it "bundles an app with source map" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
-      spago [ "bundle", "-v", "--outfile", "bundle-app.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
-      checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
-      checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
+      spago [ "bundle", "-v", "--outfile", fixture "bundle-app-map.js", "--source-maps", "--bundle-type", "app" ] >>= shouldBeSuccess
+    -- checkFixture "bundle-app.js" (fixture "bundle-app-map.js")
+    -- checkFixture "bundle-app.js.map" (fixture "bundle-app-map.js.map")
 
     Spec.it "bundles a module with source map" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
       spago [ "build" ] >>= shouldBeSuccess
-      spago [ "bundle", "--bundle-type", "module", "--outfile", "bundle-module.js", "--source-maps" ] >>= shouldBeSuccess
+      spago [ "bundle", "--bundle-type", "module", "--outfile", fixture "bundle-module-map.js", "--source-maps" ] >>= shouldBeSuccess
 
-      checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
-      checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
+--checkFixture "bundle-module.js" (fixture "bundle-module-map.js")
+--checkFixture "bundle-module.js.map" (fixture "bundle-module-map.js.map")
 


### PR DESCRIPTION
Resolves #877 
Reintroduces source map support to `spago bundle`. 

Spago already enables source maps for purs builds. All that was needed was to pass the `--sourcemap` flag to esbuild for the bundling step to have end to end source map support.
