### PR TITLE
docs-search: Upgrade to new Web.Bower.Json module

### DIFF
--- a/docs-search/spago.yaml
+++ b/docs-search/spago.yaml
@@ -7,7 +7,6 @@ package:
     - argonaut-core
     - argonaut-generic
     - arrays
-    - bower-json
     - console
     - control
     - css
@@ -21,6 +20,7 @@ package:
     - halogen-subscriptions
     - identity
     - js-uri
+    - language-purescript
     - lists
     - markdown-it
     - markdown-it-halogen

--- a/docs-search/src/Docs/Search/PackageIndex.purs
+++ b/docs-search/src/Docs/Search/PackageIndex.purs
@@ -2,8 +2,8 @@ module Docs.Search.PackageIndex where
 
 import Docs.Search.Config as Config
 import Docs.Search.Extra (stringToList)
-import Docs.Search.Score (Scores, getPackageScoreForPackageName, normalizePackageName)
-import Docs.Search.Types (PackageName, RawPackageName(..), PackageScore)
+import Docs.Search.Score (Scores, getPackageScoreForPackageName)
+import Docs.Search.Types (PackageName(..), PackageScore)
 import Docs.Search.Loader as Loader
 
 import Prelude
@@ -15,8 +15,11 @@ import Data.Maybe (Maybe)
 import Data.Newtype (unwrap)
 import Data.Search.Trie (Trie)
 import Data.Search.Trie as Trie
+import Data.Tuple as Tuple
 import Effect.Aff (Aff)
+import Safe.Coerce (coerce)
 import Web.Bower.PackageMeta (PackageMeta(..))
+import Web.Bower.PackageMeta as Bower
 
 type PackageResult =
   { name :: PackageName
@@ -56,14 +59,11 @@ mkPackageInfo packageScores pms =
       { name: packageName
       , description: description
       , score: getPackageScoreForPackageName packageScores packageName
-      , dependencies:
-          unwrap dependencies <#>
-            _.packageName >>> RawPackageName >>> normalizePackageName
-      , repository: repository <#> (_.url)
+      , dependencies: coerce $ dependencies <#> Tuple.fst
+      , repository: repository <#> unwrap >>> (_.url)
       }
-
     where
-    packageName = normalizePackageName $ RawPackageName name
+    packageName = coerce name
 
 mkScoresFromPackageIndex :: PackageIndex -> Scores
 mkScoresFromPackageIndex =

--- a/docs-search/src/Docs/Search/Score.purs
+++ b/docs-search/src/Docs/Search/Score.purs
@@ -1,6 +1,6 @@
 module Docs.Search.Score where
 
-import Docs.Search.Types (RawPackageName(..), PackageName(..), PackageInfo(..), PackageScore(..))
+import Docs.Search.Types (PackageName(..), PackageInfo(..), PackageScore(..))
 
 import Prelude
 
@@ -10,22 +10,22 @@ import Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Newtype (unwrap, wrap)
 import Data.String.CodeUnits as String
-import Web.Bower.PackageMeta (Dependencies, PackageMeta)
+import Data.Tuple (Tuple(..))
+import Data.Tuple as Tuple
+import Safe.Coerce (coerce)
+import Web.Bower.PackageMeta as Bower
 
+type Dependencies = Array (Tuple Bower.PackageName Bower.VersionRange)
 type Scores = Map PackageName PackageScore
-
-normalizePackageName :: RawPackageName -> PackageName
-normalizePackageName (RawPackageName p) =
-  fromMaybe (PackageName p) $ map wrap $ String.stripPrefix (wrap "purescript-") p
 
 -- | Construct a mapping from package names to their scores, based on number
 -- of reverse dependencies.
-mkScores :: Array PackageMeta -> Scores
+mkScores :: Array Bower.PackageMeta -> Scores
 mkScores =
   Array.foldr
-    ( \pm ->
-        updateScoresFor (unwrap pm).dependencies >>>
-          updateScoresFor (unwrap pm).devDependencies
+    ( \(Bower.PackageMeta pm) ->
+        updateScoresFor pm.dependencies >>>
+          updateScoresFor pm.devDependencies
     )
     Map.empty
 
@@ -33,10 +33,11 @@ mkScores =
   updateScoresFor :: Dependencies -> Scores -> Scores
   updateScoresFor deps scores =
     Array.foldr
-      (\dep -> Map.insertWith add dep one)
+      (\(Tuple dep _) -> Map.insertWith add (coerce dep) one)
       scores
-      (deps # unwrap >>> map (_.packageName >>> RawPackageName >>> normalizePackageName))
+      deps
 
+-- unsafeCrashWith "Docs.Search.Score"
 getPackageScore :: Scores -> PackageInfo -> PackageScore
 getPackageScore scores = case _ of
   Package p -> getPackageScoreForPackageName scores p

--- a/docs-search/src/Docs/Search/Types.purs
+++ b/docs-search/src/Docs/Search/Types.purs
@@ -32,11 +32,6 @@ derive newtype instance encodeJsonModuleName :: EncodeJson ModuleName
 instance Show ModuleName where
   show = genericShow
 
--- | Non-normalized package name, e.g. `purescript-prelude` or just `prelude`.
-newtype RawPackageName = RawPackageName String
-
-derive instance newtypeRawPackageName :: Newtype RawPackageName _
-
 -- | Normalized package name without "purescript-" prefix.
 newtype PackageName = PackageName String
 

--- a/spago.lock
+++ b/spago.lock
@@ -9,7 +9,6 @@ workspace:
         - argonaut-core
         - argonaut-generic
         - arrays
-        - bower-json
         - console
         - control
         - css
@@ -23,6 +22,7 @@ workspace:
         - halogen-subscriptions
         - identity
         - js-uri
+        - language-purescript
         - lists
         - markdown-it
         - markdown-it-halogen
@@ -174,6 +174,96 @@ workspace:
         - psci-support
       git: https://github.com/nonbili/purescript-jest.git
       ref: caf2032f2e5828337e897a99f5359c00e91cb0ee
+    json-codecs:
+      dependencies:
+        - argonaut-core
+        - arrays
+        - bifunctors
+        - either
+        - foldable-traversable
+        - foreign-object
+        - functions
+        - identity
+        - integers
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - nullable
+        - ordered-collections
+        - partial
+        - prelude
+        - record
+        - safe-coerce
+        - strings
+        - these
+        - tuples
+        - unsafe-coerce
+      git: https://github.com/JordanMartinez/purescript-json-codecs.git
+      ref: v4.0.0
+    language-cst-parser:
+      dependencies:
+        - arrays
+        - console
+        - const
+        - control
+        - effect
+        - either
+        - enums
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - identity
+        - integers
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - node-process
+        - numbers
+        - ordered-collections
+        - partial
+        - prelude
+        - st
+        - strings
+        - transformers
+        - tuples
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+      git: https://github.com/natefaubion/purescript-language-cst-parser.git
+      ref: v0.13.0
+    language-purescript:
+      dependencies:
+        - argonaut-core
+        - arrays
+        - bifunctors
+        - control
+        - datetime
+        - either
+        - enums
+        - foldable-traversable
+        - foreign-object
+        - formatters
+        - functions
+        - integers
+        - json-codecs
+        - lists
+        - maybe
+        - newtype
+        - nullable
+        - ordered-collections
+        - partial
+        - prelude
+        - safe-coerce
+        - st
+        - strings
+        - tuples
+        - unicode
+        - versions
+      git: https://github.com/JordanMartinez/purescript-language-purescript.git
+      ref: v0.1.1
     markdown-it:
       dependencies:
         - effect
@@ -199,6 +289,27 @@ workspace:
         - tuples
       git: https://github.com/paf31/purescript-memoize.git
       ref: 9960694e82adc212fd89f8ed8778cf55fcb72aeb
+    node-glob-basic:
+      dependencies:
+        - aff
+        - console
+        - effect
+        - either
+        - foldable-traversable
+        - lists
+        - maybe
+        - node-fs
+        - node-fs-aff
+        - node-path
+        - node-process
+        - ordered-collections
+        - parallel
+        - prelude
+        - refs
+        - strings
+        - tuples
+      git: https://github.com/natefaubion/purescript-node-glob-basic.git
+      ref: v1.2.2
     registry-foreign:
       git: https://github.com/purescript/registry-dev.git
       ref: 6a803c37577af368caa221a2a06d6be2079d32da
@@ -217,6 +328,70 @@ workspace:
         - prelude
       git: https://github.com/klntsky/purescript-search-trie.git
       ref: e7f7f22486a1dba22171ec885dbc2149dc815119
+    tidy:
+      dependencies:
+        - arrays
+        - control
+        - dodo-printer
+        - either
+        - foldable-traversable
+        - language-cst-parser
+        - lists
+        - maybe
+        - newtype
+        - ordered-collections
+        - partial
+        - prelude
+        - strings
+        - tuples
+      git: https://github.com/natefaubion/purescript-tidy.git
+      ref: v0.10.0
+    tidy-codegen:
+      dependencies:
+        - aff
+        - ansi
+        - arrays
+        - avar
+        - bifunctors
+        - console
+        - control
+        - dodo-printer
+        - effect
+        - either
+        - enums
+        - exceptions
+        - filterable
+        - foldable-traversable
+        - free
+        - identity
+        - integers
+        - language-cst-parser
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - node-buffer
+        - node-child-process
+        - node-fs-aff
+        - node-path
+        - node-process
+        - node-streams
+        - ordered-collections
+        - parallel
+        - partial
+        - posix-types
+        - prelude
+        - record
+        - safe-coerce
+        - st
+        - strings
+        - tidy
+        - transformers
+        - tuples
+        - type-equality
+        - unicode
+      git: https://github.com/natefaubion/purescript-tidy-codegen.git
+      ref: v4.0.0
 packages:
   aff:
     type: registry
@@ -386,20 +561,6 @@ packages:
     dependencies:
       - const
       - either
-      - newtype
-      - prelude
-      - tuples
-  bower-json:
-    type: registry
-    version: 3.0.0
-    integrity: sha256-t4zWu4agTUqWI5sdCB0cERAenZgb+e0ELQOUzggHAlU=
-    dependencies:
-      - argonaut-codecs
-      - arrays
-      - either
-      - foldable-traversable
-      - foreign-object
-      - maybe
       - newtype
       - prelude
       - tuples
@@ -985,10 +1146,38 @@ packages:
     dependencies:
       - functions
       - maybe
+  json-codecs:
+    type: git
+    url: https://github.com/JordanMartinez/purescript-json-codecs.git
+    rev: 896439470c5fd2e6a5c8cb89efcefa89ed18b40a
+    dependencies:
+      - argonaut-core
+      - arrays
+      - bifunctors
+      - either
+      - foldable-traversable
+      - foreign-object
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - nonempty
+      - nullable
+      - ordered-collections
+      - partial
+      - prelude
+      - record
+      - safe-coerce
+      - strings
+      - these
+      - tuples
+      - unsafe-coerce
   language-cst-parser:
-    type: registry
-    version: 0.12.3
-    integrity: sha256-0pnjIJMtW9u1ne+fKB4QbaCeqqwWIGE3fjEQOIU0+ks=
+    type: git
+    url: https://github.com/natefaubion/purescript-language-cst-parser.git
+    rev: 5621f2e9fa1a0df5930b95b26f922fa94c494e80
     dependencies:
       - arrays
       - console
@@ -1019,6 +1208,37 @@ packages:
       - typelevel-prelude
       - unfoldable
       - unsafe-coerce
+  language-purescript:
+    type: git
+    url: https://github.com/JordanMartinez/purescript-language-purescript.git
+    rev: b141a41333226af8702d67eb290470bba599b42a
+    dependencies:
+      - argonaut-core
+      - arrays
+      - bifunctors
+      - control
+      - datetime
+      - either
+      - enums
+      - foldable-traversable
+      - foreign-object
+      - formatters
+      - functions
+      - integers
+      - json-codecs
+      - lists
+      - maybe
+      - newtype
+      - nullable
+      - ordered-collections
+      - partial
+      - prelude
+      - safe-coerce
+      - st
+      - strings
+      - tuples
+      - unicode
+      - versions
   lazy:
     type: registry
     version: 6.0.0
@@ -1876,6 +2096,22 @@ packages:
       - record
       - tuples
       - unsafe-coerce
+  versions:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-+7qxEsCbSl8JDsOsGQO/XxCfcCYak13lJHEXmCzUjIs=
+    dependencies:
+      - control
+      - either
+      - foldable-traversable
+      - functions
+      - integers
+      - lists
+      - maybe
+      - orders
+      - parsing
+      - partial
+      - strings
   web-clipboard:
     type: registry
     version: 5.0.0

--- a/spago.yaml
+++ b/spago.yaml
@@ -247,33 +247,7 @@ workspace:
         - language-cst-parser
         - strings
         - tuples
-    json-codecs:
-      git: https://github.com/JordanMartinez/purescript-json-codecs.git
-      ref: v4.0.0
-      dependencies:
-        - argonaut-core
-        - arrays
-        - bifunctors
-        - either
-        - foldable-traversable
-        - foreign-object
-        - functions
-        - identity
-        - integers
-        - lists
-        - maybe
-        - newtype
-        - nonempty
-        - nullable
-        - ordered-collections
-        - partial
-        - prelude
-        - record
-        - safe-coerce
-        - strings
-        - these
-        - tuples
-        - unsafe-coerce
+    json-codecs: "4.0.0"
     node-glob-basic:
       git: https://github.com/natefaubion/purescript-node-glob-basic.git
       ref: "v1.2.2"

--- a/spago.yaml
+++ b/spago.yaml
@@ -85,6 +85,36 @@ workspace:
         - psci-support
       git: https://github.com/nonbili/purescript-jest.git
       ref: caf2032f2e5828337e897a99f5359c00e91cb0ee
+    language-purescript:
+      ref: v0.1.1
+      git: https://github.com/JordanMartinez/purescript-language-purescript.git
+      dependencies:
+        - argonaut-core
+        - arrays
+        - bifunctors
+        - control
+        - datetime
+        - either
+        - enums
+        - foldable-traversable
+        - foreign-object
+        - formatters
+        - functions
+        - integers
+        - json-codecs
+        - lists
+        - maybe
+        - newtype
+        - nullable
+        - ordered-collections
+        - partial
+        - prelude
+        - safe-coerce
+        - st
+        - strings
+        - tuples
+        - unicode
+        - versions
     markdown-it:
       dependencies:
         - effect
@@ -120,4 +150,148 @@ workspace:
         - prelude
       git: https://github.com/klntsky/purescript-search-trie.git
       ref: e7f7f22486a1dba22171ec885dbc2149dc815119
-
+    language-cst-parser:
+      git: https://github.com/natefaubion/purescript-language-cst-parser.git
+      ref: "v0.13.0"
+      dependencies:
+        - "arrays"
+        - "console"
+        - "const"
+        - "control"
+        - "effect"
+        - "either"
+        - "enums"
+        - "foldable-traversable"
+        - "free"
+        - "functions"
+        - "functors"
+        - "identity"
+        - "integers"
+        - "lazy"
+        - "lists"
+        - "maybe"
+        - "newtype"
+        - "node-process"
+        - "numbers"
+        - "ordered-collections"
+        - "partial"
+        - "prelude"
+        - "st"
+        - "strings"
+        - "transformers"
+        - "tuples"
+        - "typelevel-prelude"
+        - "unfoldable"
+        - "unsafe-coerce"
+    tidy-codegen:
+      git: https://github.com/natefaubion/purescript-tidy-codegen.git
+      ref: v4.0.0
+      dependencies:
+        - aff
+        - ansi
+        - arrays
+        - avar
+        - bifunctors
+        - console
+        - control
+        - dodo-printer
+        - effect
+        - either
+        - enums
+        - exceptions
+        - filterable
+        - foldable-traversable
+        - free
+        - identity
+        - integers
+        - language-cst-parser
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - node-buffer
+        - node-child-process
+        - node-fs-aff
+        - node-path
+        - node-process
+        - node-streams
+        - ordered-collections
+        - parallel
+        - partial
+        - posix-types
+        - prelude
+        - record
+        - safe-coerce
+        - st
+        - strings
+        - tidy
+        - transformers
+        - tuples
+        - type-equality
+        - unicode
+    tidy:
+      git: https://github.com/natefaubion/purescript-tidy.git
+      ref: "v0.10.0"
+      dependencies:
+        - arrays
+        - control
+        - dodo-printer
+        - either
+        - foldable-traversable
+        - lists
+        - maybe
+        - newtype
+        - ordered-collections
+        - partial
+        - prelude
+        - language-cst-parser
+        - strings
+        - tuples
+    json-codecs:
+      git: https://github.com/JordanMartinez/purescript-json-codecs.git
+      ref: v4.0.0
+      dependencies:
+        - argonaut-core
+        - arrays
+        - bifunctors
+        - either
+        - foldable-traversable
+        - foreign-object
+        - functions
+        - identity
+        - integers
+        - lists
+        - maybe
+        - newtype
+        - nonempty
+        - nullable
+        - ordered-collections
+        - partial
+        - prelude
+        - record
+        - safe-coerce
+        - strings
+        - these
+        - tuples
+        - unsafe-coerce
+    node-glob-basic:
+      git: https://github.com/natefaubion/purescript-node-glob-basic.git
+      ref: "v1.2.2"
+      dependencies:
+        - aff
+        - console
+        - effect
+        - either
+        - foldable-traversable
+        - lists
+        - maybe
+        - node-fs
+        - node-fs-aff
+        - node-path
+        - node-process
+        - ordered-collections
+        - parallel
+        - prelude
+        - refs
+        - strings
+        - tuples


### PR DESCRIPTION
Updates `docs-search` to depend on `purescript-language-purescript` instead of `bower-json` for the module `Web.Bower.PackageMeta`.

Note: most of the `purescript-language-purescript` library functionality is not used, I'm aiming to replace the types and codecs in `docs-search` piecemeal.