### PR TITLE
Update docs-search/README, and attribute to klntsky

### DIFF
--- a/docs-search/README.md
+++ b/docs-search/README.md
@@ -1,48 +1,9 @@
-# purescript-docs-search
-
-[![Build status](https://github.com/purescript/purescript-docs-search/actions/workflows/build.yml/badge.svg)](https://github.com/purescript/purescript-docs-search/actions/workflows/build.yml)
-
-An app that adds search capabilities to generated documentation for PureScript code.
+# docs-search
+These packages provide the ability to index and search purescript documentation.
 
 It supports nearly-all functionality of [Pursuit](https://github.com/purescript/pursuit), including querying by type.
 
-## Installing
+## License
 
-When using [spago](https://github.com/spacchetti/spago), you don't need to install this app manually: run `spago docs` or `spago search`.
+This folder ports [purescript-docs-search](https://github.com/purescript/purescript-docs-search), which is licensed under [BSD-3-Clause](https://github.com/purescript/purescript-docs-search/blob/v0.0.12/package.json#L40) thanks to [klntsky](https://github.com/klntsky).
 
-Otherwise, use NPM (`npm install purescript-docs-search`) or [npx](https://github.com/npm/npx): `npx purescript-docs-search`.
-
-## Usage
-
-There are two usage scenarios:
-
-### Patching static documentation
-
-Use `purescript-docs-search build-index` command to patch HTML files located in `generated-docs/html`. You then will be able to search for declarations or types:
-
-![Preview](preview.png)
-
-The user interface of the app is optimised for keyboard-only use.
-
-**S** hotkey can be used to focus on the search field, **Escape** can be used to leave it. Pressing **Escape** twice will close the search results listing.
-
-### Using the CLI
-
-Running `purescript-docs-search` within a project directory will open an interactive command-line session.
-
-Note that unlike in Pursuit, most relevant results will appear last.
-
-A quick demo:
-
-[![asciicast](https://asciinema.org/a/Hexie5JoWjlAqLqv2IgafIdb9.svg)](https://asciinema.org/a/Hexie5JoWjlAqLqv2IgafIdb9)
-
-You may notice that the CLI offers slightly better results than the web interface. This is a performance tradeoff.
-
-## Development
-
-```
-npm install
-npm run build # or build-dev to skip JS compression stage
-```
-
-Use `spago docs --no-search && ./dist/purescript-docs-search.cjs build-index` to generate the docs and patch them using the local version of the app.


### PR DESCRIPTION
I shortened the readme for `docs-search` since its more of a set of libraries than an app at this point. 

I templated attribution for @klntsky from a similar notice in `language-purescript`: https://github.com/JordanMartinez/purescript-language-purescript/blob/v0.1.1/README.md#license