### PR TITLE
Revert `spago build` back to using a single `purs compile` call when building multi-package workspace

### DIFF
--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -817,9 +817,10 @@ mkReplEnv replArgs dependencies supportPackage = do
 
   purs <- Purs.getPurs
 
-  selected <- case workspace.selected of
-    Just s -> pure $ Build.SinglePackageGlobs s
-    Nothing -> pure $ Build.AllWorkspaceGlobs workspace.packageSet
+  let
+    selected = case workspace.selected of
+      Just s -> [ s ]
+      Nothing -> Config.getWorkspacePackages workspace.packageSet
 
   pure
     { purs

--- a/src/Spago/Command/Docs.purs
+++ b/src/Spago/Command/Docs.purs
@@ -12,6 +12,7 @@ import Node.Process as Process
 import Spago.Command.Build as Build
 import Spago.Command.Fetch as Fetch
 import Spago.Config (Workspace)
+import Spago.Config as Config
 import Spago.Purs (Purs, DocsFormat(..))
 import Spago.Purs as Purs
 
@@ -33,7 +34,7 @@ run = do
   let
     globs = Build.getBuildGlobs
       { withTests: true
-      , selected: Build.AllWorkspaceGlobs workspace.packageSet
+      , selected: Config.getWorkspacePackages workspace.packageSet
       , dependencies: Fetch.toAllDependencies dependencies
       , depsOnly
       }

--- a/src/Spago/Command/Publish.purs
+++ b/src/Spago/Command/Publish.purs
@@ -124,7 +124,7 @@ publish _args = do
 
   -- We then need to check that the dependency graph is accurate. If not, queue the errors
   let allDependencies = Fetch.toAllDependencies dependencies
-  let globs = Build.getBuildGlobs { selected: Build.SinglePackageGlobs selected, withTests: false, dependencies: allDependencies, depsOnly: false }
+  let globs = Build.getBuildGlobs { selected: [ selected ], withTests: false, dependencies: allDependencies, depsOnly: false }
   maybeGraph <- Graph.runGraph globs []
   for_ maybeGraph \graph -> do
     graphCheckErrors <- Graph.toImportErrors selected <$> runSpago (Record.union { graph, selected } env) Graph.checkImports

--- a/src/Spago/Command/Repl.purs
+++ b/src/Spago/Command/Repl.purs
@@ -8,7 +8,7 @@ import Spago.Prelude
 import Data.Map as Map
 import Spago.Command.Build as Build
 import Spago.Command.Fetch as Fetch
-import Spago.Config (PackageMap)
+import Spago.Config (PackageMap, WorkspacePackage)
 import Spago.Purs (Purs)
 import Spago.Purs as Purs
 
@@ -19,7 +19,7 @@ type ReplEnv a =
   , depsOnly :: Boolean
   , logOptions :: LogOptions
   , pursArgs :: Array String
-  , selected :: Build.SelectedPackageGlob
+  , selected :: Array WorkspacePackage
   | a
   }
 

--- a/src/Spago/Command/Run.purs
+++ b/src/Spago/Command/Run.purs
@@ -102,7 +102,7 @@ run = do
           , depsOnly: false
           -- Here we include tests as well, because we use this code for `spago run` and `spago test`
           , withTests: true
-          , selected: Build.SinglePackageGlobs selected
+          , selected: [ selected ]
           }
       Purs.graph globs [] >>= case _ of
         Left err -> logWarn $ "Could not decode the output of `purs graph`, error: " <> CA.printJsonDecodeError err

--- a/test/Spago/Build/Polyrepo.purs
+++ b/test/Spago/Build/Polyrepo.purs
@@ -321,18 +321,7 @@ spec = Spec.describe "polyrepo" do
             , packageName: Nothing
             }
         }
-      let
-        hasAllPkgsInRightBuildOrder stdErr = do
-          let
-            exp = Array.intercalate "\n"
-              [ "Building packages in the following order:"
-              , "1) case-three-package-c"
-              , "2) case-three-package-b"
-              , "3) case-three-package-a"
-              ]
-          unless (String.contains (Pattern exp) stdErr) do
-            Assert.fail $ "STDERR did not contain text:\n" <> exp <> "\n\nStderr was:\n" <> stdErr
-      spago [ "build" ] >>= check { stdout: mempty, stderr: hasAllPkgsInRightBuildOrder, result: isRight }
+      spago [ "build" ] >>= shouldBeSuccess
 
   {-
   ```mermaid
@@ -413,16 +402,7 @@ spec = Spec.describe "polyrepo" do
       }
     let
       hasExpectedModules stdErr = do
-        let
-          exp = Array.intercalate "\n"
-            [ "Detected 2 modules with the same module name across 2 or more packages defined in this workspace."
-            , "1) Module \"Subpackage.SameName.Main\" was defined in the following packages:"
-            , "  - case-four-package-a   at path: " <> Path.concat [ "package-a", "src", "Main.purs" ]
-            , "  - case-four-package-b   at path: " <> Path.concat [ "package-b", "src", "Main.purs" ]
-            , "2) Module \"Subpackage.SameName.Test.Main\" was defined in the following packages:"
-            , "  - case-four-package-a   at path: " <> Path.concat [ "package-a", "test", "Main.purs" ]
-            , "  - case-four-package-b   at path: " <> Path.concat [ "package-b", "test", "Main.purs" ]
-            ]
+        let exp = "Module Subpackage.SameName.Main has been defined multiple times"
 
         unless (String.contains (Pattern exp) stdErr) do
           Assert.fail $ "STDERR did not contain text:\n" <> exp <> "\n\nStderr was:\n" <> stdErr

--- a/test/Spago/Build/Polyrepo.purs
+++ b/test/Spago/Build/Polyrepo.purs
@@ -88,7 +88,7 @@ spec = Spec.describe "polyrepo" do
                 )
         }
 
-  Spec.describe "topological build order" do
+  Spec.describe "inter-workspace package dependencies" do
 
     {-
     ```mermaid

--- a/test/Spago/Build/Polyrepo.purs
+++ b/test/Spago/Build/Polyrepo.purs
@@ -143,7 +143,7 @@ spec = Spec.describe "polyrepo" do
             , packageName: Nothing
             }
         }
-      spago [ "build", "--verbose" ] >>= shouldBeSuccess
+      spago [ "build" ] >>= shouldBeSuccess
 
     {-
     ```mermaid


### PR DESCRIPTION
### Description of the change

Fixes #1051

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
