### PR TITLE
Spago docs --deps-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ For example to generate ctags for use in your editor:
 $ spago docs --format ctags
 ```
 
-Sometimes you'd like to pull up docs for dependencies even when you have compilation errors in your project. This good use case for the --deps-only flag:
+Sometimes you'd like to pull up docs for dependencies even when you have compilation errors in your project. This is a good use case for the --deps-only flag:
 
 ```console
 $ spago docs --deps-only`

--- a/README.md
+++ b/README.md
@@ -932,11 +932,18 @@ If you wish for the documentation to be opened in browser when generated, you ca
 $ spago docs --open
 ```
 
-To build the documentation as Markdown instead of HTML, or to generate tags for your project,
-you can pass a `format` flag:
+You can customize the output to other formats beyond html. Supported formats include ctags, etags, and markdown.
+For example to generate ctags for use in your editor:
 ```console
 $ spago docs --format ctags
 ```
+
+Sometimes you'd like to pull up docs for dependencies even when you have compilation errors in your project. This good use case for the --deps-only flag:
+
+```console
+$ spago docs --deps-only`
+```
+
 
 ### Alternate backends
 

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -264,3 +264,11 @@ sourceMaps =
     ( O.long "source-maps"
         <> O.help "Creates a source map for your bundle"
     )
+
+depsOnly :: Parser Boolean
+depsOnly =
+  O.switch
+    ( O.long "deps-only"
+        <> O.help "Build depedencies only"
+    )
+

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -363,8 +363,7 @@ publishArgsParser =
 
 docsArgsParser :: Parser DocsArgs
 docsArgsParser = Optparse.fromRecord
-  -- TODO: --deps-only
-  { depsOnly: pure false :: Parser Boolean
+  { depsOnly: Flags.depsOnly
   , open: O.switch
       ( O.long "open"
           <> O.short 'o'


### PR DESCRIPTION
### Description of the change

Resolves #1020 

With this change I believe we're basically at parity with the old spago docs command. 

(There was a --no-search flag in the old spago which skips indexing, but I don't see a strong reason to bring that back)

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

