### PR TITLE
Update flake and lockfile, add spago and purs-backend-es to shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694499547,
-        "narHash": "sha256-R7xMz1Iia6JthWRHDn36s/E248WB1/je62ovC/dUVKI=",
+        "lastModified": 1697851979,
+        "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5f018cf150e29aac26c61dac0790ea023c46b24",
+        "rev": "5550a85a087c04ddcace7f892b0bdc9d8bb080c8",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1694484110,
-        "narHash": "sha256-QXxECuZwRl+Mr+7OfhQSmTWaKsI6RjvBqjqMOxMBtPg=",
+        "lastModified": 1697766752,
+        "narHash": "sha256-jTGJhKuv/KPsMOnfIUSqoTckf4jo3e+9e0XY2cvXbD4=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "7591ffe2adb930305e5e7c4be19c3a7cc8a4ee7b",
+        "rev": "1a6676b94f064113980b142454e3eefeecce5dcc",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688610262,
-        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
         "owner": "thomashoneyman",
         "repo": "slimlock",
-        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
             purs
             purs-tidy
             purs-backend-es
+            spago-unstable
 
             nodejs
             esbuild

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,12 @@
         };
       in {
         devShells.default = pkgs.mkShell {
+          name = "spago";
           buildInputs = with pkgs; [
-            purs-bin.purs-0_15_10
-            # TODO: we need to get purescript-overlay to track the latest versions
-            # spago-unstable
-            purs-tidy-bin.purs-tidy-0_10_0
+            purs
+            purs-tidy
+            purs-backend-es
+
             nodejs
             esbuild
             gh

--- a/spago.lock
+++ b/spago.lock
@@ -330,6 +330,7 @@ workspace:
         - tuples
       git: https://github.com/natefaubion/purescript-node-glob-basic.git
       ref: v1.2.2
+    ordered-collections: 3.1.1
     registry-foreign:
       git: https://github.com/purescript/registry-dev.git
       ref: 6a803c37577af368caa221a2a06d6be2079d32da
@@ -1575,8 +1576,8 @@ packages:
       - tuples
   ordered-collections:
     type: registry
-    version: 3.0.0
-    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
+    version: 3.1.1
+    integrity: sha256-boSYHmlz4aSbwsNN4VxiwCStc0t+y1F7BXmBS+1JNtI=
     dependencies:
       - arrays
       - foldable-traversable


### PR DESCRIPTION
### Description of the change

This minor internal-only update does a couple things:

1. Updates the flake to the latest purescript-overlay (giving access to spago 0.93.18, among other things)
2. Adds spago to the dev shell. Spago is used in the package.json scripts but we don't actually specify a version anywhere; now, the latest spago from purescript-overlay will be used.
3. Adds purs-backend-es to the dev shell. Right now the optimizer isn't used, but I've added it so it's easy to integrate into e.g. the publish workflow at some time; it provides noticeable speed improvements so it would be nice to publish an optimized spago.
4. Updates the spago.lock file. Something must be funky about the lockfile generation, as this was out-of-date regarding the updated ordered-collections version from a few days ago.