### PR TITLE
Add timings to verbose output

### DIFF
--- a/spago.lock
+++ b/spago.lock
@@ -138,6 +138,7 @@ workspace:
         - registry-lib
         - spago-core
         - strings
+        - stringutils
         - transformers
         - tuples
         - unsafe-coerce
@@ -1976,6 +1977,17 @@ packages:
       - tuples
       - unfoldable
       - unsafe-coerce
+  stringutils:
+    type: registry
+    version: 0.0.12
+    integrity: sha256-t63QWBlp49U0nRqUcFryKflSJsNKGTQAHKjn24/+ooI=
+    dependencies:
+      - arrays
+      - integers
+      - maybe
+      - partial
+      - prelude
+      - strings
   tailrec:
     type: registry
     version: 6.1.0

--- a/spago.yaml
+++ b/spago.yaml
@@ -43,6 +43,7 @@ package:
     - registry-lib
     - spago-core
     - strings
+    - stringutils
     - transformers
     - tuples
     - unsafe-coerce

--- a/test/Spago/Install.purs
+++ b/test/Spago/Install.purs
@@ -4,6 +4,7 @@ import Test.Prelude
 
 import Data.Array as Array
 import Data.Map as Map
+import Effect.Now as Now
 import Node.FS.Aff as FSA
 import Node.Path as Path
 import Registry.Version as Version
@@ -238,7 +239,8 @@ spec = Spec.around withTempDir do
 
     Spec.it "can build with a newer (but still compatible) compiler than the one in the package set" \{ spago } -> do
       spago [ "init", "--package-set", "10.0.0" ] >>= shouldBeSuccess
-      purs <- runSpago { logOptions: { color: false, verbosity: LogQuiet } } Purs.getPurs
+      startingTime <- liftEffect $ Now.now
+      purs <- runSpago { logOptions: { color: false, verbosity: LogQuiet, startingTime } } Purs.getPurs
       -- The package set 10.0.0 has purescript 0.15.4, so we check that we have a newer version
       case purs.version > mkVersion "0.15.4" of
         true -> pure unit

--- a/test/Spago/Upgrade.purs
+++ b/test/Spago/Upgrade.purs
@@ -2,6 +2,7 @@ module Test.Spago.Upgrade where
 
 import Test.Prelude
 
+import Effect.Now as Now
 import Spago.Core.Config (SetAddress(..))
 import Spago.Core.Config as Core
 import Spago.Log (LogVerbosity(..))
@@ -19,7 +20,8 @@ spec = Spec.around withTempDir do
       -- we can't just check a fixture here, as there are new package set versions all the time.
       -- so we read the config file, and check that the package set version is more recent than the one we started with
       let initialVersion = mkVersion "20.0.1"
-      maybeConfig <- runSpago { logOptions: { color: false, verbosity: LogQuiet } } (Core.readConfig "spago.yaml")
+      startingTime <- liftEffect $ Now.now
+      maybeConfig <- runSpago { logOptions: { color: false, verbosity: LogQuiet, startingTime } } (Core.readConfig "spago.yaml")
       case maybeConfig of
         Right { yaml: { workspace: Just { package_set: Just (SetFromRegistry { registry }) } } } | registry > initialVersion -> pure unit
         Right { yaml: c } -> Assert.fail $ "Could not upgrade the package set, config: " <> printJson Core.configCodec c


### PR DESCRIPTION
This PR adds to the verbose output the amount of milliseconds elapsed from the beginning of the execution, so that it's easier to find slow bits that can be sped up.

cc @JordanMartinez @finnhodgkin 

It looks something like this (bikeshedding on how they should look like is welcome):

![image](https://github.com/purescript/spago/assets/5480361/ce32715e-8ea5-4d76-82d4-1c49ed27c07a)

