### PR TITLE
Use the database to cache the index and metadata

### DIFF
--- a/src/Spago/Db.js
+++ b/src/Spago/Db.js
@@ -4,7 +4,7 @@ export const connectImpl = (path, logger) => {
   logger("Connecting to database at " + path);
   let db = new Database(path, {
     fileMustExist: false,
-    verbose: logger,
+    // verbose: logger,
   });
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
@@ -19,16 +19,24 @@ export const connectImpl = (path, logger) => {
     , packageName TEXT NOT NULL
     , packageVersion TEXT NOT NULL
     , PRIMARY KEY (packageSetVersion, packageName, packageVersion)
-    , FOREIGN KEY (packageSetVersion) REFERENCES package_sets(version))`).run();
-  // TODO: this is here as a placeholder, but not settled yet
-  // db.prepare(`CREATE TABLE IF NOT EXISTS package_versions
-  //   ( name TEXT NOT NULL
-  //   , version TEXT NOT NULL
-  //   , published INTEGER NOT NULL
-  //   , date TEXT NOT NULL
-  //   , manifest TEXT NOT NULL
-  //   , location TEXT NOT NULL
-  //   , PRIMARY KEY (name, version))`).run();
+    , FOREIGN KEY (packageSetVersion) REFERENCES package_sets(version)
+    )`).run();
+  db.prepare(`CREATE TABLE IF NOT EXISTS last_git_pull
+    ( key TEXT PRIMARY KEY NOT NULL
+    , date TEXT NOT NULL
+    )`).run();
+  db.prepare(`CREATE TABLE IF NOT EXISTS package_metadata
+    ( name TEXT PRIMARY KEY NOT NULL
+    , metadata TEXT NOT NULL
+    )`).run();
+  // it would be lovely if we'd have a foreign key on package_metadata, but that would
+  // require reading metadatas before manifests, which we can't always guarantee
+  db.prepare(`CREATE TABLE IF NOT EXISTS package_manifests
+    ( name TEXT NOT NULL
+    , version TEXT NOT NULL
+    , manifest TEXT NOT NULL
+    , PRIMARY KEY (name, version)
+    )`).run();
   return db;
 };
 
@@ -37,12 +45,6 @@ export const insertPackageSetImpl = (db, packageSet) => {
     "INSERT INTO package_sets (version, compiler, date) VALUES (@version, @compiler, @date)"
   ).run(packageSet);
 };
-
-export const insertPackageVersionImpl = (db, packageVersion) => {
-  db.prepare(
-    "INSERT INTO package_versions (name, version, published, date, manifest, location) VALUES (@name, @version, @published, @date, @manifest, @location)"
-  ).run(packageVersion);
-}
 
 export const insertPackageSetEntryImpl = (db, packageSetEntry) => {
   db.prepare(
@@ -64,17 +66,6 @@ export const selectPackageSetsImpl = (db) => {
   return row;
 }
 
-export const selectPackageVersionImpl = (db, name, version) => {
-  const row = db
-    .prepare("SELECT * FROM package_versions WHERE name = ? AND version = ? LIMIT 1")
-    .get(name, version);
-  return row;
-}
-
-export const unpublishPackageVersionImpl = (db, name, version) => {
-  db.prepare("UPDATE package_versions SET published = 0 WHERE name = ? AND version = ?").run(name, version);
-}
-
 export const selectPackageSetEntriesBySetImpl = (db, packageSetVersion) => {
   const row = db
     .prepare("SELECT * FROM package_set_entries WHERE packageSetVersion = ?")
@@ -87,4 +78,41 @@ export const selectPackageSetEntriesByPackageImpl = (db, packageName, packageVer
     .prepare("SELECT * FROM package_set_entries WHERE packageName = ? AND packageVersion = ?")
     .all(packageName, packageVersion);
   return row;
+}
+
+export const getLastPullImpl = (db, key) => {
+  const row = db
+    .prepare("SELECT * FROM last_git_pull WHERE key = ? LIMIT 1")
+    .get(key);
+  return row?.date;
+}
+
+export const updateLastPullImpl = (db, key, date) => {
+  db.prepare("INSERT OR REPLACE INTO last_git_pull (key, date) VALUES (@key, @date)").run({ key, date });
+}
+
+export const getManifestImpl = (db, name, version) => {
+  const row = db
+    .prepare("SELECT * FROM package_manifests WHERE name = ? AND version = ? LIMIT 1")
+    .get(name, version);
+  return row?.manifest;
+}
+
+export const insertManifestImpl = (db, name, version, manifest) => {
+  db.prepare("INSERT OR IGNORE INTO package_manifests (name, version, manifest) VALUES (@name, @version, @manifest)").run({ name, version, manifest });
+}
+
+export const removeManifestImpl = (db, name, version) => {
+  db.prepare("DELETE FROM package_manifests WHERE name = ? AND version = ?").run(name, version);
+}
+
+export const getMetadataImpl = (db, name) => {
+  const row = db
+    .prepare("SELECT * FROM package_metadata WHERE name = ? LIMIT 1")
+    .get(name);
+  return row?.metadata;
+}
+
+export const insertMetadataImpl = (db, name, metadata) => {
+  db.prepare("INSERT OR REPLACE INTO package_metadata (name, metadata) VALUES (@name, @metadata)").run({ name, metadata });
 }

--- a/src/Spago/Db.purs
+++ b/src/Spago/Db.purs
@@ -5,33 +5,38 @@ module Spago.Db
   , PackageSetEntry
   , PackageVersion
   , connect
-  , selectPackageSets
-  , selectLatestPackageSetByCompiler
+  , getLastPull
+  , getManifest
+  , getMetadata
+  , insertManifest
+  , insertMetadata
   , insertPackageSet
   , insertPackageSetEntry
   , packageSetCodec
+  , selectLatestPackageSetByCompiler
+  , selectPackageSets
+  , updateLastPull
   ) where
 
 import Spago.Prelude
 
 import Data.Array as Array
-import Data.Codec.Argonaut as Json
 import Data.Codec.Argonaut.Record as CA.Record
 import Data.DateTime (Date, DateTime(..))
 import Data.DateTime as Date
+import Data.Either as Either
 import Data.Formatter.DateTime as DateTime
+import Data.Map as Map
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3)
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4)
 import Effect.Uncurried as Uncurried
-import Node.Path as Path
 import Registry.Internal.Codec as Internal.Codec
 import Registry.Internal.Format as Internal.Format
-import Registry.Location as Location
 import Registry.Manifest as Manifest
+import Registry.Metadata as Metadata
 import Registry.PackageName as PackageName
 import Registry.Version as Version
-import Spago.Paths as Paths
 
 --------------------------------------------------------------------------------
 -- API
@@ -47,9 +52,6 @@ connect { database, logger } = Uncurried.runEffectFn2 connectImpl database (Uncu
 insertPackageSet :: Db -> PackageSet -> Effect Unit
 insertPackageSet db = Uncurried.runEffectFn2 insertPackageSetImpl db <<< packageSetToJs
 
-insertPackageVersion :: Db -> PackageVersion -> Effect Unit
-insertPackageVersion db = Uncurried.runEffectFn2 insertPackageVersionImpl db <<< packageVersionToJs
-
 insertPackageSetEntry :: Db -> PackageSetEntry -> Effect Unit
 insertPackageSetEntry db = Uncurried.runEffectFn2 insertPackageSetEntryImpl db <<< packageSetEntryToJs
 
@@ -63,14 +65,6 @@ selectLatestPackageSetByCompiler db compiler = do
   maybePackageSet <- Nullable.toMaybe <$> Uncurried.runEffectFn2 selectLatestPackageSetByCompilerImpl db (Version.print compiler)
   pure $ packageSetFromJs =<< maybePackageSet
 
-selectPackageVersion :: Db -> PackageName -> Version -> Effect (Maybe PackageVersion)
-selectPackageVersion db packageName version = do
-  maybePackageVersion <- Nullable.toMaybe <$> Uncurried.runEffectFn3 selectPackageVersionImpl db (PackageName.print packageName) (Version.print version)
-  pure $ packageVersionFromJs =<< maybePackageVersion
-
-unpublishPackageVersion :: Db -> PackageName -> Version -> Effect Unit
-unpublishPackageVersion db packageName version = Uncurried.runEffectFn3 unpublishPackageVersionImpl db (PackageName.print packageName) (Version.print version)
-
 selectPackageSetEntriesBySet :: Db -> Version -> Effect (Array PackageSetEntry)
 selectPackageSetEntriesBySet db packageSetVersion = do
   packageSetEntries <- Uncurried.runEffectFn2 selectPackageSetEntriesBySetImpl db (Version.print packageSetVersion)
@@ -80,6 +74,34 @@ selectPackageSetEntriesByPackage :: Db -> PackageName -> Version -> Effect (Arra
 selectPackageSetEntriesByPackage db packageName version = do
   packageSetEntries <- Uncurried.runEffectFn3 selectPackageSetEntriesByPackageImpl db (PackageName.print packageName) (Version.print version)
   pure $ Array.mapMaybe packageSetEntryFromJs packageSetEntries
+
+getLastPull :: Db -> String -> Effect (Maybe DateTime)
+getLastPull db key = do
+  maybePull <- Nullable.toMaybe <$> Uncurried.runEffectFn2 getLastPullImpl db key
+  pure $ (Either.hush <<< DateTime.unformat Internal.Format.iso8601DateTime) =<< maybePull
+
+updateLastPull :: Db -> String -> DateTime -> Effect Unit
+updateLastPull db key date = Uncurried.runEffectFn3 updateLastPullImpl db key (DateTime.format Internal.Format.iso8601DateTime date)
+
+getManifest :: Db -> PackageName -> Version -> Effect (Maybe Manifest)
+getManifest db packageName version = do
+  maybeManifest <- Nullable.toMaybe <$> Uncurried.runEffectFn3 getManifestImpl db (PackageName.print packageName) (Version.print version)
+  pure $ (Either.hush <<< parseJson Manifest.codec) =<< maybeManifest
+
+insertManifest :: Db -> PackageName -> Version -> Manifest -> Effect Unit
+insertManifest db packageName version manifest = Uncurried.runEffectFn4 insertManifestImpl db (PackageName.print packageName) (Version.print version) (printJson Manifest.codec manifest)
+
+getMetadata :: Db -> PackageName -> Effect (Maybe Metadata)
+getMetadata db packageName = do
+  maybeMetadata <- Nullable.toMaybe <$> Uncurried.runEffectFn2 getMetadataImpl db (PackageName.print packageName)
+  pure $ (Either.hush <<< parseJson Metadata.codec) =<< maybeMetadata
+
+insertMetadata :: Db -> PackageName -> Metadata -> Effect Unit
+insertMetadata db packageName metadata@(Metadata { unpublished }) = do
+  Uncurried.runEffectFn3 insertMetadataImpl db (PackageName.print packageName) (printJson Metadata.codec metadata)
+  -- we also do a pass of removing the cached manifests that have been unpublished
+  for_ (Map.toUnfoldable unpublished :: Array _) \(Tuple version _) -> do
+    Uncurried.runEffectFn3 removeManifestImpl db (PackageName.print packageName) (Version.print version)
 
 --------------------------------------------------------------------------------
 -- Table types and conversions
@@ -143,25 +165,6 @@ packageSetFromJs p = hush do
   date <- map Date.date $ DateTime.unformat Internal.Format.iso8601Date p.date
   pure $ { version, compiler, date }
 
-packageVersionToJs :: PackageVersion -> PackageVersionJs
-packageVersionToJs { name, version, published, date, manifest, location } =
-  { name: PackageName.print name
-  , version: Version.print version
-  , published: if published then 1 else 0
-  , date: DateTime.format Internal.Format.iso8601DateTime date
-  , manifest: printJson Manifest.codec manifest
-  , location: printJson Location.codec location
-  }
-
-packageVersionFromJs :: PackageVersionJs -> Maybe PackageVersion
-packageVersionFromJs p = hush do
-  name <- PackageName.parse p.name
-  version <- Version.parse p.version
-  date <- DateTime.unformat Internal.Format.iso8601DateTime p.date
-  manifest <- lmap Json.printJsonDecodeError $ parseJson Manifest.codec p.manifest
-  location <- lmap Json.printJsonDecodeError $ parseJson Location.codec p.location
-  pure $ { name, version, published: p.published == 1, date, manifest, location }
-
 packageSetEntryToJs :: PackageSetEntry -> PackageSetEntryJs
 packageSetEntryToJs { packageSetVersion, packageName, packageVersion } =
   { packageSetVersion: Version.print packageSetVersion
@@ -193,18 +196,26 @@ foreign import connectImpl :: EffectFn2 FilePath (EffectFn1 String Unit) Db
 
 foreign import insertPackageSetImpl :: EffectFn2 Db PackageSetJs Unit
 
-foreign import insertPackageVersionImpl :: EffectFn2 Db PackageVersionJs Unit
-
 foreign import insertPackageSetEntryImpl :: EffectFn2 Db PackageSetEntryJs Unit
 
 foreign import selectLatestPackageSetByCompilerImpl :: EffectFn2 Db String (Nullable PackageSetJs)
 
 foreign import selectPackageSetsImpl :: EffectFn1 Db (Array PackageSetJs)
 
-foreign import selectPackageVersionImpl :: EffectFn3 Db String String (Nullable PackageVersionJs)
-
-foreign import unpublishPackageVersionImpl :: EffectFn3 Db String String Unit
-
 foreign import selectPackageSetEntriesBySetImpl :: EffectFn2 Db String (Array PackageSetEntryJs)
 
 foreign import selectPackageSetEntriesByPackageImpl :: EffectFn3 Db String String (Array PackageSetEntryJs)
+
+foreign import getLastPullImpl :: EffectFn2 Db String (Nullable String)
+
+foreign import updateLastPullImpl :: EffectFn3 Db String String Unit
+
+foreign import getManifestImpl :: EffectFn3 Db String String (Nullable String)
+
+foreign import insertManifestImpl :: EffectFn4 Db String String String Unit
+
+foreign import removeManifestImpl :: EffectFn3 Db String String Unit
+
+foreign import getMetadataImpl :: EffectFn2 Db String (Nullable String)
+
+foreign import insertMetadataImpl :: EffectFn3 Db String String Unit


### PR DESCRIPTION
...so that we don't hit the filesystem all the time.

This fixes #1083 - a no-op build of this repo goes from 2.5s to 2.0s on my machine, because of the better cache.