### PR TITLE
Organize 'pedantic' errors fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,9 @@ spago test
 
 # To see tests' stdout/stderr output while the tests are running, run
 SPAGO_TEST_DEBUG=1 spago
+
+# To overwrite fixture's with the test's run, run
+SPAGO_TEST_ACCEPT=1 spago
 ```
 
 ## Developing docs

--- a/src/Spago/Command/Build.purs
+++ b/src/Spago/Command/Build.purs
@@ -150,10 +150,10 @@ run opts = do
     eitherGraph <- Graph.runGraph globs opts.pursArgs
     graph <- either die pure eitherGraph
     env <- ask
-    errors <- map Array.fold $ for pedanticPkgs \(Tuple selected options) -> do
+    checkResults <- map Array.fold $ for pedanticPkgs \(Tuple selected options) -> do
       Graph.toImportErrors selected options <$> runSpago (Record.union { selected } env) (Graph.checkImports graph)
-    unless (Array.null errors) do
-      die' errors
+    unless (Array.null checkResults) do
+      die $ Graph.formatImportErrors checkResults
 
 -- TODO: if we are building with all the packages (i.e. selected = Nothing),
 -- then we could use the graph to remove outdated modules from `output`!

--- a/src/Spago/Command/Publish.purs
+++ b/src/Spago/Command/Publish.purs
@@ -131,7 +131,7 @@ publish _args = do
   case eitherGraph of
     Right graph -> do
       graphCheckErrors <- Graph.toImportErrors selected { reportSrc: true, reportTest: false } <$> runSpago (Record.union { selected } env) (Graph.checkImports graph)
-      for_ graphCheckErrors addError
+      for_ graphCheckErrors (addError <<< Graph.formatImportErrors <<< pure)
     Left err ->
       die err
 

--- a/test-fixtures/pedantic/check-direct-import-transitive-dependency-both.txt
+++ b/test-fixtures/pedantic/check-direct-import-transitive-dependency-both.txt
@@ -13,21 +13,18 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   maybe
     from `Main`, which imports:
       Data.Maybe
 
-
-Run the following command to install them all:
-  spago install -p pedantic maybe
-
-
-❌ Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   control
     from `Test.Main`, which imports:
       Control.Alt
 
-
-Run the following command to install them all:
-  spago install --test-deps -p pedantic control
+These errors can be fixed by running the below command(s):
+spago install -p pedantic maybe
+spago install -p pedantic --test-deps control

--- a/test-fixtures/pedantic/check-direct-import-transitive-dependency-test.txt
+++ b/test-fixtures/pedantic/check-direct-import-transitive-dependency-test.txt
@@ -13,11 +13,12 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   control
     from `Test.Main`, which imports:
       Control.Alt
 
-
-Run the following command to install them all:
-  spago install --test-deps -p pedantic control
+These errors can be fixed by running the below command(s):
+spago install -p pedantic --test-deps control

--- a/test-fixtures/pedantic/check-direct-import-transitive-dependency.txt
+++ b/test-fixtures/pedantic/check-direct-import-transitive-dependency.txt
@@ -13,11 +13,12 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   control
     from `Main`, which imports:
       Control.Alt
 
-
-Run the following command to install them all:
-  spago install -p pedantic control
+These errors can be fixed by running the below command(s):
+spago install -p pedantic control

--- a/test-fixtures/pedantic/check-pedantic-packages.txt
+++ b/test-fixtures/pedantic/check-pedantic-packages.txt
@@ -13,31 +13,28 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - console
   - effect
   - either
 
-
-❌ Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+Sources for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   newtype
     from `Main`, which imports:
       Data.Newtype
 
-
-Run the following command to install them all:
-  spago install -p pedantic newtype
-
-
-❌ Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - tuples
 
-
-❌ Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   either
     from `Test.Main`, which imports:
       Data.Either
 
-
-Run the following command to install them all:
-  spago install --test-deps -p pedantic either
+These errors can be fixed by running the below command(s):
+spago uninstall -p pedantic console effect either
+spago install -p pedantic newtype
+spago uninstall -p pedantic --test-deps tuples
+spago install -p pedantic --test-deps either

--- a/test-fixtures/pedantic/check-unused-dependency-in-source.txt
+++ b/test-fixtures/pedantic/check-unused-dependency-in-source.txt
@@ -13,12 +13,13 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - console
   - effect
 
-
-❌ Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
+Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:
   console
     from `Test.Main`, which imports:
       Effect.Class.Console
@@ -26,6 +27,6 @@ Looking for unused and undeclared transitive dependencies...
     from `Test.Main`, which imports:
       Effect
 
-
-Run the following command to install them all:
-  spago install --test-deps -p pedantic console effect
+These errors can be fixed by running the below command(s):
+spago uninstall -p pedantic console effect
+spago install -p pedantic --test-deps console effect

--- a/test-fixtures/pedantic/check-unused-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-dependency.txt
@@ -13,6 +13,11 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - console
   - effect
+
+These errors can be fixed by running the below command(s):
+spago uninstall -p pedantic console effect

--- a/test-fixtures/pedantic/check-unused-source-and-test-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-source-and-test-dependency.txt
@@ -13,11 +13,16 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - console
   - effect
 
-
-❌ Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - console
   - effect
+
+These errors can be fixed by running the below command(s):
+spago uninstall -p pedantic console effect
+spago uninstall -p pedantic --test-deps console effect

--- a/test-fixtures/pedantic/check-unused-test-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-test-dependency.txt
@@ -13,5 +13,10 @@ Errors       0     0     0
 
 Looking for unused and undeclared transitive dependencies...
 
-❌ Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+❌ Found unused and/or undeclared transitive dependencies:
+
+Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
   - newtype
+
+These errors can be fixed by running the below command(s):
+spago uninstall -p pedantic --test-deps newtype


### PR DESCRIPTION
### Description of the change

Fixes #1042. Also adds the `SPAGO_TEST_ACCEPT=1` CLI flag to overwrite fixtures with current outputs.

I also switched the CLI flags around for `--test-deps`:
```diff
spago install -p packageName foo
-spago install --test-deps -p packageName foo
+spago install -p packageName --test-deps foo
```
### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
