### PR TITLE
Bump execa to 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-          - os: macOS-latest
+          # - os: ubuntu-latest
+          # - os: macOS-latest
           - os: windows-latest
     steps:
       # We set LF endings so that the Windows environment is consistent with the rest

--- a/spago.lock
+++ b/spago.lock
@@ -310,6 +310,7 @@ workspace:
         - prelude
         - strings
         - tuples
+    node-execa: 2.0.0
     node-glob-basic:
       git: https://github.com/natefaubion/purescript-node-glob-basic.git
       ref: v1.2.2
@@ -1367,8 +1368,8 @@ packages:
       - unsafe-coerce
   node-execa:
     type: registry
-    version: 1.3.2
-    integrity: sha256-kKVeJC+s5Pfye9aJ2V55NUfSyETZ2DZxPP02+zpNS/M=
+    version: 2.0.0
+    integrity: sha256-u/0ptGWlzb81TmzYDYJhJ2EfU+CBZELr1vgfzvgxQVM=
     dependencies:
       - aff
       - arrays

--- a/spago.yaml
+++ b/spago.yaml
@@ -271,3 +271,4 @@ workspace:
         - strings
         - tuples
     ordered-collections: "3.1.1"
+    node-execa: "2.0.0"


### PR DESCRIPTION
### Description of the change

Troubleshooting PR for #1129. We're on `node-execa@1.3.2`. I'm curious to see whether any of the updates between then and `5.0.0` cause the 'command too long' error. Fabrizio reminded me that CI built before the node update PR, and we still don't have an explanation as to why it worked before that PR.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
