### PR TITLE
Fix readme bug on specifying test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,7 +771,7 @@ Where:
       - console
       - prelude
       - lib1 # <------ Note the dependency here
-    tests:
+    test:
       main: Test.Lib2.Main
       dependencies:
         - spec
@@ -903,7 +903,7 @@ package:
     - effect
     - console
     - prelude
-  tests:
+  test:
     main: Test.Main
     dependencies:
       - spec


### PR DESCRIPTION
Config doesn't work with `tests` and also because of this https://github.com/purescript/spago/issues/1165 it's not clear