### PR TITLE
mv .envrc → .envrc.example to allow personalization

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# For Nix flake users who want an automatic dev shell
 if command -v nix;
 then
   export NIXPKGS_ALLOW_UNFREE=1

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /bin/bundle.js
 /bin/docs-search-app.js
 .direnv
+.envrc
 *.node
 **/.vscode
 **/.DS_Store


### PR DESCRIPTION
### Description of the change

`.envrc` is meant to be a personalized space for including any switches th user wants, not forced by maintainers (if that behavior is desired, provide an `.envrc.example` file). The current script assumes the user wants to use Nix, has flakes enabled, & does a Nix executable check which is unnecessary for the user who already has it installed… but also nothing in the flake.nix is requires nonfree packages. A user may want to use their `.envrc` for something else.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
