### PR TITLE
Properly ignore nested workspaces - fix the missing case where a nested workspace config didn't have a package

### DIFF
--- a/core/src/FS.purs
+++ b/core/src/FS.purs
@@ -5,11 +5,11 @@ module Spago.FS
   , getInBetweenPaths
   , isLink
   , ls
-  , cp
   , mkdirp
   , moveSync
   , copyFileSync
   , copyFile
+  , copyTree
   , readJsonFile
   , readTextFile
   , readYamlDocFile
@@ -53,8 +53,12 @@ copyFile { src, dst } = liftAff $ FS.Aff.copyFile src dst
 
 foreign import cpImpl :: String -> String -> Effect Unit
 
-cp :: forall m. MonadEffect m => { src :: FilePath, dst :: FilePath } -> m Unit
-cp { src, dst } = liftEffect $ cpImpl src dst
+-- | Copy a file or directory. The directory can have contents.
+-- | Note: if `src` is a directory it will copy everything inside of this directory,
+-- | not the entire directory itself.
+-- | Note: if `src` is a file, `dst` cannot be a directory
+copyTree :: forall m. MonadEffect m => { src :: FilePath, dst :: FilePath } -> m Unit
+copyTree { src, dst } = liftEffect $ cpImpl src dst
 
 foreign import ensureFileSyncImpl :: String -> Effect Unit
 

--- a/src/Spago/Command/Fetch.purs
+++ b/src/Spago/Command/Fetch.purs
@@ -374,7 +374,7 @@ getGitPackageInLocalCache name package = do
             let commitHashLocation = Config.getPackageLocation name (GitPackage $ package { ref = ref })
             logDebug $ "Copying the repo also to " <> commitHashLocation
             FS.mkdirp $ Path.concat [ Paths.localCachePackagesPath, PackageName.print name ]
-            FS.cp { src: localPackageLocation, dst: commitHashLocation }
+            FS.copyTree { src: localPackageLocation, dst: commitHashLocation }
 
 getPackageDependencies :: forall a. PackageName -> Package -> Spago (FetchEnv a) (Maybe (Map PackageName Range))
 getPackageDependencies packageName package = case package of

--- a/test-fixtures/monorepo/ignore-nested-workspaces/expected-stderr.txt
+++ b/test-fixtures/monorepo/ignore-nested-workspaces/expected-stderr.txt
@@ -1,0 +1,11 @@
+Reading Spago workspace configuration...
+
+✅ Selecting package to build: ignore-nested-workspaces
+
+Downloading dependencies...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✅ Build succeeded.

--- a/test-fixtures/monorepo/ignore-nested-workspaces/nested/lib/spago.yaml
+++ b/test-fixtures/monorepo/ignore-nested-workspaces/nested/lib/spago.yaml
@@ -1,0 +1,9 @@
+package:
+  name: lib
+  dependencies:
+    - console
+    - effect
+    - prelude
+  test:
+    main: Test.Main
+    dependencies: []

--- a/test-fixtures/monorepo/ignore-nested-workspaces/nested/spago.yaml
+++ b/test-fixtures/monorepo/ignore-nested-workspaces/nested/spago.yaml
@@ -1,0 +1,1 @@
+workspace: {}

--- a/test-fixtures/monorepo/ignore-nested-workspaces/spago.yaml
+++ b/test-fixtures/monorepo/ignore-nested-workspaces/spago.yaml
@@ -1,0 +1,13 @@
+package:
+  name: ignore-nested-workspaces
+  dependencies:
+    - console
+    - effect
+    - prelude
+  test:
+    main: Test.Main
+    dependencies: []
+workspace:
+  package_set:
+    registry: 50.3.2
+  extra_packages: {}

--- a/test-fixtures/monorepo/ignore-nested-workspaces/src/Main.purs
+++ b/test-fixtures/monorepo/ignore-nested-workspaces/src/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  log "🍝"
+

--- a/test/Spago/Build/Polyrepo.purs
+++ b/test/Spago/Build/Polyrepo.purs
@@ -184,6 +184,11 @@ spec = Spec.describe "polyrepo" do
     spago [ "uninstall", "-p", "root", "console", "effect", "prelude" ] >>= shouldBeSuccess
     spago [ "build", "-p", "root", "--pedantic-packages" ] >>= shouldBeSuccess
 
+  Spec.it "ignore nested workspaces" \{ spago, fixture } -> do
+    FS.copyTree { src: fixture "monorepo/ignore-nested-workspaces", dst: "." }
+    spago [ "build" ] >>= shouldBeSuccess
+    spago [ "build" ] >>= shouldBeSuccessErr (fixture "monorepo/ignore-nested-workspaces/expected-stderr.txt")
+
   Spec.describe "warning censoring and error-promotion" do
     let
       setupPackageWithUnusedNameWarning packageName deps strict censorShadowedName includeTestCode = do


### PR DESCRIPTION
In this PR we also add some fixtures for the package under test (rather than creating it programmatically), so that we can hopefully shrink the amount of code one needs to write for tests.