### PR TITLE
Trimming the prefix_by message while censoring warning

### DIFF
--- a/src/Spago/Psa.purs
+++ b/src/Spago/Psa.purs
@@ -179,7 +179,7 @@ shouldPrintWarning = case _ of
       let
         tests = arr <#> case _ of
           ByCode c -> \code _ -> c == code
-          ByMessagePrefix prefix -> \_ msg -> isJust $ String.stripPrefix (String.Pattern prefix) msg
+          ByMessagePrefix prefix -> \_ msg -> isJust $ String.stripPrefix (String.Pattern $ String.trim prefix) (String.trim msg)
       -- We return `true` to print the warning.
       -- If an element was found (i.e. `Just` is returned), then one of the tests succeeded, 
       -- so we should not print the warning and return false here.

--- a/test-fixtures/build/censor-warnings/spago.yaml
+++ b/test-fixtures/build/censor-warnings/spago.yaml
@@ -1,0 +1,14 @@
+package:
+  name: foo
+  dependencies:
+    - console
+    - effect
+    - prelude
+  build:
+    censor_project_warnings:
+      - by_prefix: "Module Prelude"
+      - "UnusedName"
+
+workspace:
+  package_set:
+    registry: 41.5.0

--- a/test-fixtures/build/censor-warnings/src/Main.purs
+++ b/test-fixtures/build/censor-warnings/src/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+
+import Effect
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+ let unused_var = 1
+ pure unit

--- a/test/Prelude.purs
+++ b/test/Prelude.purs
@@ -377,3 +377,9 @@ escapePathInErrMsg :: Array String -> String
 escapePathInErrMsg = case Process.platform of
   Just Platform.Win32 -> Array.intercalate "\\"
   _ -> Array.intercalate "/"
+
+assertWarning :: forall m. MonadThrow Error m => Array String -> Boolean -> String -> m Unit
+assertWarning paths shouldHave stdErr  = do
+  when (not $ Array.all (\exp -> shouldHave == (String.contains (Pattern exp) stdErr)) paths) do
+    Assert.fail $ "STDERR contained one or more texts:\n" <> show paths <> "\n\nStderr was:\n" <> stdErr
+

--- a/test/Spago/Build/Monorepo.purs
+++ b/test/Spago/Build/Monorepo.purs
@@ -129,10 +129,8 @@ spec = Spec.describe "monorepo" do
           , escapePathInErrMsg [ "package-b", "src", "Main.purs:6:13" ]
           , escapePathInErrMsg [ "package-c", "src", "Main.purs:6:13" ]
           ]
-        shouldNotHaveWarning stdErr = do
-          when (Array.any (\exp -> String.contains (Pattern exp) stdErr) paths) do
-            Assert.fail $ "STDERR contained one or more texts:\n" <> show paths <> "\n\nStderr was:\n" <> stdErr
-      spago [ "build" ] >>= check { stdout: mempty, stderr: shouldNotHaveWarning, result: isRight }
+        shouldNotHaveWarning = assertWarning paths false
+      spago [ "build" ] >>= check { stdout: mempty, stderr: shouldNotHaveWarning , result: isRight } 
 
     Spec.it "build fails when 'strict: true' and warnings were not censored" \{ spago, fixture } -> do
       FS.copyTree { src: fixture "monorepo/strict-true-uncensored-warnings", dst: "." }
@@ -141,9 +139,7 @@ spec = Spec.describe "monorepo" do
           [ "[1/2 UnusedName] " <> escapePathInErrMsg [ "package-b", "src", "Main.purs:6:13" ]
           , "[2/2 UnusedName] " <> escapePathInErrMsg [ "package-b", "test", "Main.purs:6:13" ]
           ]
-        hasUnusedWarningError stdErr = do
-          unless (Array.any (\exp -> String.contains (Pattern exp) stdErr) errs) do
-            Assert.fail $ "STDERR did not contain texts:\n" <> show errs <> "\n\nStderr was:\n" <> stdErr
+        hasUnusedWarningError =  assertWarning errs true
       spago [ "build" ] >>= check { stdout: mempty, stderr: hasUnusedWarningError, result: isLeft }
 
   Spec.describe "passing --ensure-ranges flag..." do


### PR DESCRIPTION
One of the ways to censor warnings is by using `by_prefix`. Some warning messages have additional leading whitespaces so the filtering is not happening correctly, so this PR fixes this by doing the filtering after trimming the text.

TODO

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
