### PR TITLE
Fix lockfile not updating when a local package set changed on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1231,11 +1231,9 @@ workspace:
     registry: 11.10.0
     # Or it could just point to a URL of a custom package set
     # See the "Custom package sets" section for more info on making one.
-    # The `hash` field is actually optional and you should not add it.
-    # It will be tacked on by Spago, to not download the set over and over.
-    # Remove this field if you'd like Spago to fetch from the remote again.
     url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.7-20230207/packages.json
-    hash: sha256-UZaygzoqEhhYh2lzUqbiNfOR9J+WNRc9SkQPmoo90jM=
+    # It is also possible to point to a local package set instead:
+    path: ./my-custom-package-set.json
 
   # This section defines any other packages that you'd like to include
   # in the build. It's optional, in case you just want to use the ones

--- a/src/Spago/Config.purs
+++ b/src/Spago/Config.purs
@@ -435,6 +435,12 @@ shouldComputeNewLockfile { workspace, workspacePackages } workspaceLock =
     || (fromMaybe Map.empty workspace.extra_packages /= workspaceLock.extra_packages)
     -- and the package set address needs to match - we have no way to match the package set contents at this point, so we let it be
     || (workspace.package_set /= map _.address workspaceLock.package_set)
+    -- and the package set is not a local file - if it is then we always recompute the lockfile because we have no way to check if it's changed
+    ||
+      ( case workspace.package_set of
+          Just (Core.SetFromPath _) -> true
+          _ -> false
+      )
 
 getPackageLocation :: PackageName -> Package -> FilePath
 getPackageLocation name = Paths.mkRelative <<< case _ of

--- a/test-fixtures/build/local-package-set-lockfile/local-package-set.json
+++ b/test-fixtures/build/local-package-set-lockfile/local-package-set.json
@@ -1,0 +1,10 @@
+{
+  "compiler": "0.15.10",
+  "published": "2023-09-30",
+  "version": "1.0.0",
+  "packages": {
+    "prelude": "6.0.1",
+    "console": "6.1.0",
+    "effect": "4.0.0"
+  }
+}

--- a/test-fixtures/build/local-package-set-lockfile/new-package-set.json
+++ b/test-fixtures/build/local-package-set-lockfile/new-package-set.json
@@ -1,0 +1,11 @@
+{
+  "compiler": "0.15.10",
+  "published": "2023-09-30",
+  "version": "1.0.0",
+  "packages": {
+    "prelude": "6.0.1",
+    "typelevel-prelude": "7.0.0",
+    "console": "6.1.0",
+    "effect": "4.0.0"
+  }
+}

--- a/test-fixtures/build/local-package-set-lockfile/spago.lock.new
+++ b/test-fixtures/build/local-package-set-lockfile/spago.lock.new
@@ -1,0 +1,42 @@
+workspace:
+  packages:
+    local-package-set-lockfile:
+      path: ./
+      dependencies:
+        - console
+        - effect
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - console
+        - effect
+        - prelude
+  package_set:
+    address:
+      path: ./local-package-set.json
+    compiler: ">=0.15.10 <0.16.0"
+    content:
+      console: 6.1.0
+      effect: 4.0.0
+      prelude: 6.0.1
+      typelevel-prelude: 7.0.0
+  extra_packages: {}
+packages:
+  console:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=
+    dependencies:
+      - effect
+      - prelude
+  effect:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
+    dependencies:
+      - prelude
+  prelude:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []

--- a/test-fixtures/build/local-package-set-lockfile/spago.lock.old
+++ b/test-fixtures/build/local-package-set-lockfile/spago.lock.old
@@ -1,0 +1,41 @@
+workspace:
+  packages:
+    local-package-set-lockfile:
+      path: ./
+      dependencies:
+        - console
+        - effect
+        - prelude
+      test_dependencies: []
+      build_plan:
+        - console
+        - effect
+        - prelude
+  package_set:
+    address:
+      path: ./local-package-set.json
+    compiler: ">=0.15.10 <0.16.0"
+    content:
+      console: 6.1.0
+      effect: 4.0.0
+      prelude: 6.0.1
+  extra_packages: {}
+packages:
+  console:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=
+    dependencies:
+      - effect
+      - prelude
+  effect:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
+    dependencies:
+      - prelude
+  prelude:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []

--- a/test-fixtures/build/local-package-set-lockfile/spago.yaml
+++ b/test-fixtures/build/local-package-set-lockfile/spago.yaml
@@ -1,0 +1,10 @@
+package:
+  name: local-package-set-lockfile
+  dependencies:
+    - console
+    - effect
+    - prelude
+workspace:
+  package_set:
+    path: ./local-package-set.json
+  extra_packages: {}


### PR DESCRIPTION
As per title - Spago did not pick up changes to a local package set, and happily rebuilt with the old lockfile content. Test included.