### PR TITLE
Use registry lib with 150 char limit on package names

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -64,7 +64,7 @@ workspace:
   extraPackages:
     registry-lib:
       git: https://github.com/purescript/registry-dev.git
-      ref: d7d35c94cc286528e506a6a7ca78d22c84b251c9
+      ref: 6feb62497ef7c3668bea89d11e9c2edb3a12dbd4
       subdir: lib
     html-parser-halogen:
       dependencies:


### PR DESCRIPTION
addresses https://github.com/purescript/spago/issues/1086

### Description of the change

TODO

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
