### PR TITLE
Always fetch the registry when using registry commands

### DIFF
--- a/src/Spago/Command/Registry.purs
+++ b/src/Spago/Command/Registry.purs
@@ -97,8 +97,7 @@ type RegistryPackageSetsArgs =
 
 packageSets :: RegistryPackageSetsArgs -> Spago (RegistryEnv _) Unit
 packageSets { latest, json } = do
-  { db } <- ask
-  availableSets <- liftEffect $ Db.selectPackageSets db
+  availableSets <- Registry.listPackageSets
 
   let
     sets = case latest of


### PR DESCRIPTION
..to fix the issue reported in https://github.com/purescript/spago/issues/1221#issuecomment-2156807173.

This is a proper followup on #1214, and we fix the issue by proxying all the calls to the `Spago.Db` module through the `Spago.Registry` module, where we check if we should refresh the cache in the Db. Ideally we'd merge the two modules and not export those bare functions, but that would get more complicated and would require some thinking to expose a unified API.