### PR TITLE
fix: gitignoringGlob stack safety + perf

### DIFF
--- a/src/Spago/Glob.js
+++ b/src/Spago/Glob.js
@@ -1,7 +1,7 @@
 import mm from 'micromatch';
 import * as fsWalk from '@nodelib/fs.walk';
 
-export const micromatch = options => mm.matcher(options.include, options);
+export const testGlob = glob => mm.matcher(glob.include, {ignore: glob.ignore});
 
 export const fsWalkImpl = Left => Right => respond => options => path => () => {
   const entryFilter = entry => options.entryFilter(entry)();

--- a/src/Spago/Glob.js
+++ b/src/Spago/Glob.js
@@ -1,7 +1,7 @@
 import mm from 'micromatch';
 import * as fsWalk from '@nodelib/fs.walk';
 
-export const micromatch = options => patterns => mm.matcher(patterns, options);
+export const micromatch = options => mm.matcher(options.include, options);
 
 export const fsWalkImpl = Left => Right => respond => options => path => () => {
   const entryFilter = entry => options.entryFilter(entry)();

--- a/src/Spago/Glob.purs
+++ b/src/Spago/Glob.purs
@@ -58,15 +58,15 @@ gitignoreGlob base =
     >>> Record.rename (Proxy @"right") (Proxy @"include")
 
   where
-    isComment = isJust <<< String.stripPrefix (String.Pattern "#")
-    leadingSlash = String.stripPrefix (String.Pattern "/")
-    trailingSlash = String.stripSuffix (String.Pattern "/")
+  isComment = isJust <<< String.stripPrefix (String.Pattern "#")
+  leadingSlash = String.stripPrefix (String.Pattern "/")
+  trailingSlash = String.stripSuffix (String.Pattern "/")
 
-    unpackPattern :: String -> String
-    unpackPattern pattern
-      | Just a <- trailingSlash pattern = unpackPattern a
-      | Just a <- leadingSlash pattern = a <> "/**"
-      | otherwise = "**/" <> pattern <> "/**"
+  unpackPattern :: String -> String
+  unpackPattern pattern
+    | Just a <- trailingSlash pattern = unpackPattern a
+    | Just a <- leadingSlash pattern = a <> "/**"
+    | otherwise = "**/" <> pattern <> "/**"
 
 fsWalk :: String -> Array String -> Array String -> Aff (Array Entry)
 fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
@@ -88,10 +88,11 @@ fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
             pats = splitGlob $ gitignoreGlob base gitignore
             patIsOk g = not $ any (testGlob g) includePatterns
             newPats = filter (patIsOk) pats
-          in do
-            void
-              $ Ref.modify (_ <> fold newPats)
-              $ ignoreMatcherRef
+          in
+            do
+              void
+                $ Ref.modify (_ <> fold newPats)
+                $ ignoreMatcherRef
 
     -- Should `fsWalk` recurse into this directory?
     deepFilter :: Entry -> Effect Boolean

--- a/src/Spago/Glob.purs
+++ b/src/Spago/Glob.purs
@@ -3,7 +3,7 @@ module Spago.Glob (gitignoringGlob) where
 import Spago.Prelude
 
 import Control.Alternative (guard)
-import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
+import Control.Monad.Maybe.Trans (runMaybeT)
 import Control.Monad.Trans.Class (lift)
 import Data.Array as Array
 import Data.Filterable (filter)

--- a/src/Spago/Glob.purs
+++ b/src/Spago/Glob.purs
@@ -89,10 +89,7 @@ fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
             patIsOk g = not $ any (testGlob g) includePatterns
             newPats = filter (patIsOk) pats
           in
-            do
-              void
-                $ Ref.modify (_ <> fold newPats)
-                $ ignoreMatcherRef
+            void $ Ref.modify (_ <> fold newPats) $ ignoreMatcherRef
 
     -- Should `fsWalk` recurse into this directory?
     deepFilter :: Entry -> Effect Boolean

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -41,22 +41,22 @@ main :: Effect Unit
 main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ Spec.Reporter.consoleReporter ] do
   Spec.describe "spago" do
     -- TODO: script
-    Init.spec
-    Sources.spec
-    Install.spec
-    Uninstall.spec
-    Ls.spec
-    Build.spec
-    Run.spec
-    Test.spec
-    Bundle.spec
-    Registry.spec
-    Docs.spec
-    Upgrade.spec
-    Publish.spec
-    Graph.spec
+    -- Init.spec
+    -- Sources.spec
+    -- Install.spec
+    -- Uninstall.spec
+    -- Ls.spec
+    -- Build.spec
+    -- Run.spec
+    -- Test.spec
+    -- Bundle.spec
+    -- Registry.spec
+    -- Docs.spec
+    -- Upgrade.spec
+    -- Publish.spec
+    -- Graph.spec
     Spec.describe "miscellaneous" do
-      Lock.spec
-      Unit.spec
+      -- Lock.spec
+      -- Unit.spec
       Glob.spec
-      Errors.spec
+      -- Errors.spec

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -41,22 +41,22 @@ main :: Effect Unit
 main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ Spec.Reporter.consoleReporter ] do
   Spec.describe "spago" do
     -- TODO: script
-    -- Init.spec
-    -- Sources.spec
-    -- Install.spec
-    -- Uninstall.spec
-    -- Ls.spec
-    -- Build.spec
-    -- Run.spec
-    -- Test.spec
-    -- Bundle.spec
-    -- Registry.spec
-    -- Docs.spec
-    -- Upgrade.spec
-    -- Publish.spec
-    -- Graph.spec
+    Init.spec
+    Sources.spec
+    Install.spec
+    Uninstall.spec
+    Ls.spec
+    Build.spec
+    Run.spec
+    Test.spec
+    Bundle.spec
+    Registry.spec
+    Docs.spec
+    Upgrade.spec
+    Publish.spec
+    Graph.spec
     Spec.describe "miscellaneous" do
-      -- Lock.spec
-      -- Unit.spec
+      Lock.spec
+      Unit.spec
       Glob.spec
-      -- Errors.spec
+      Errors.spec

--- a/test/Spago/Glob.purs
+++ b/test/Spago/Glob.purs
@@ -63,11 +63,13 @@ spec = Spec.around globTmpDir do
         a <- Glob.gitignoringGlob p ["**/apple"]
         a `Assert.shouldEqual` ["fruits/special/apple", "src/fruits/apple"]
 
-      Spec.it "does not respect a .gitignore pattern that conflicts with search" \p -> do
-        for_ ["/fruits", "fruits", "fruits/", "**/fruits", "fruits/**", "**/fruits/**"] \gitignore -> do
-          FS.writeTextFile (Path.concat [p, ".gitignore"]) gitignore
-          a <- Glob.gitignoringGlob p ["fruits/apple/**"]
-          a `Assert.shouldEqual` ["fruits/apple"]
+      for_ ["/fruits", "fruits", "fruits/", "**/fruits", "fruits/**", "**/fruits/**"] \gitignore -> do
+        Spec.focus $ Spec.it
+          ("does not respect a .gitignore pattern that conflicts with search: " <> gitignore)
+          \p -> do
+            FS.writeTextFile (Path.concat [p, ".gitignore"]) gitignore
+            a <- Glob.gitignoringGlob p ["fruits/apple/**"]
+            a `Assert.shouldEqual` ["fruits/apple"]
 
       Spec.it "respects some .gitignore patterns" \p -> do
         FS.writeTextFile (Path.concat [p, ".gitignore"]) """/fruits\n/src"""


### PR DESCRIPTION
### Description of the change

fixes #1231 

Before, we were eagerly turning string glob patterns to matching functions `String -> Boolean`, and adding new patterns with `||`. The instance `(HeytingAlgebra b) => HeytingAlgebra (a -> b)` isn't stack safe, causing sufficiently large gitignore files to overflow the call stack.

Now, we accumulate the patterns themselves and build them into micromatch patterns when we evaluate them. The actual call to `micromatch` costs practically nothing, so this flat-out wins time & space cost (as well as fixing the stack-safety issue)

```purs
-- Instead of composing the matcher functions, we could also keep a growing array of
-- patterns and regenerate the matcher on every append. I don't know which option is
-- more performant, but composing functions is more convenient.
```
Turns out we've learned which option is more performant :sweat_smile:

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [x] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
