### PR TITLE
Fix glob performance on large monorepos

### DIFF
--- a/src/Spago/Command/Build.purs
+++ b/src/Spago/Command/Build.purs
@@ -153,8 +153,9 @@ run opts = do
     if Array.null pedanticPkgs || opts.depsOnly then
       pure true
     else do
-      logInfo $ "Looking for unused and undeclared transitive dependencies..."
+      logInfo "Looking for unused and undeclared transitive dependencies..."
       eitherGraph <- Graph.runGraph globs opts.pursArgs
+      logDebug "Decoded the output of `purs graph` successfully. Analyzing dependencies..."
       eitherGraph # either (prepareToDie >>> (_ $> false)) \graph -> do
         env <- ask
         checkResults <- map Array.fold $ for pedanticPkgs \(Tuple selected options) -> do

--- a/src/Spago/Glob.js
+++ b/src/Spago/Glob.js
@@ -13,5 +13,3 @@ export const fsWalkImpl = Left => Right => respond => options => path => () => {
 };
 
 export const isFile = dirent => dirent.isFile();
-
-export const direntToString = dirent => JSON.stringify(dirent);

--- a/src/Spago/Glob.js
+++ b/src/Spago/Glob.js
@@ -1,7 +1,7 @@
 import mm from 'micromatch';
 import * as fsWalk from '@nodelib/fs.walk';
 
-export const testGlob = glob => mm.matcher(glob.include, {ignore: glob.ignore});
+export const testGlob = glob => mm.matcher(glob.include, { ignore: glob.ignore });
 
 export const fsWalkImpl = Left => Right => respond => options => path => () => {
   const entryFilter = entry => options.entryFilter(entry)();
@@ -14,3 +14,4 @@ export const fsWalkImpl = Left => Right => respond => options => path => () => {
 
 export const isFile = dirent => dirent.isFile();
 
+export const direntToString = dirent => JSON.stringify(dirent);

--- a/src/Spago/Glob.purs
+++ b/src/Spago/Glob.purs
@@ -9,9 +9,9 @@ import Data.Array as Array
 import Data.Filterable (filter)
 import Data.Foldable (any, fold)
 import Data.String as String
+import Data.String as String.CodePoint
 import Data.Traversable (traverse_)
 import Effect.Aff as Aff
-import Effect.Class.Console as Console
 import Effect.Ref as Ref
 import Node.FS.Sync as SyncFS
 import Node.Path as Path
@@ -33,11 +33,6 @@ type FsWalkOptions = { entryFilter :: Entry -> Effect Boolean, deepFilter :: Ent
 foreign import data DirEnt :: Type
 foreign import isFile :: DirEnt -> Boolean
 
-foreign import direntToString :: DirEnt -> String
-
-instance Show DirEnt where
-  show = direntToString
-
 foreign import fsWalkImpl
   :: (forall a b. a -> Either a b)
   -> (forall a b. b -> Either a b)
@@ -53,24 +48,25 @@ gitignoreFileToGlob base =
     >>> Array.filter (not <<< or [ String.null, isComment ])
     >>> partitionMap
       ( \line -> do
-          let
-            resolve a = Path.concat [ base, a ]
-            pat a = withForwardSlashes $ resolve $ unpackPattern a
+          let pattern lin = withForwardSlashes $ Path.concat [ base, gitignorePatternToGlobPattern lin ]
           case String.stripPrefix (String.Pattern "!") line of
-            Just negated -> Left $ pat negated
-            Nothing -> Right $ pat line
+            Just negated -> Left $ pattern negated
+            Nothing -> Right $ pattern line
       )
     >>> (\{ left, right } -> { ignore: left, include: right })
 
   where
   isComment = isJust <<< String.stripPrefix (String.Pattern "#")
-  leadingSlash = String.stripPrefix (String.Pattern "/")
-  trailingSlash = String.stripSuffix (String.Pattern "/")
+  dropSuffixSlash str = fromMaybe str $ String.stripSuffix (String.Pattern "/") str
+  dropPrefixSlash str = fromMaybe str $ String.stripPrefix (String.Pattern "/") str
 
-  unpackPattern :: String -> String
-  unpackPattern pattern
-    | Just a <- trailingSlash pattern = unpackPattern a
-    | Just a <- leadingSlash pattern = a <> "/**"
+  leadingSlash str = String.codePointAt 0 str == Just (String.CodePoint.codePointFromChar '/')
+  trailingSlash str = String.codePointAt (String.length str - 1) str == Just (String.CodePoint.codePointFromChar '/')
+
+  gitignorePatternToGlobPattern :: String -> String
+  gitignorePatternToGlobPattern pattern
+    | trailingSlash pattern = gitignorePatternToGlobPattern $ dropSuffixSlash pattern
+    | leadingSlash pattern = dropPrefixSlash pattern <> "/**"
     | otherwise = "**/" <> pattern <> "/**"
 
 fsWalk :: String -> Array String -> Array String -> Aff (Array Entry)
@@ -89,8 +85,8 @@ fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
 
   let
     -- Update the ignoreMatcherRef with the patterns from a .gitignore file
-    updateGitignore :: Entry -> Effect Unit
-    updateGitignore entry =
+    updateIgnoreMatcherWithGitignore :: Entry -> Effect Unit
+    updateIgnoreMatcherWithGitignore entry = do
       try (SyncFS.readTextFile UTF8 entry.path)
         >>= traverse_ \gitignore -> do
           let
@@ -108,17 +104,16 @@ fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
     -- Should `fsWalk` recurse into this directory?
     deepFilter :: Entry -> Effect Boolean
     deepFilter entry = fromMaybe false <$> runMaybeT do
-      lift $ Console.log $ "deepFilter: " <> show entry
       isCanceled <- lift $ Ref.read canceled
       guard $ not isCanceled
-      shouldIgnore <- lift $ testGlob <$> Ref.read ignoreGlobRef
+      shouldIgnore <- lift $ Ref.read ignoreMatcherRef
       pure $ not $ shouldIgnore $ Path.relative cwd entry.path
 
     -- Should `fsWalk` retain this entry for the result array?
     entryFilter :: Entry -> Effect Boolean
     entryFilter entry = do
-      Console.log $ "entryFilter: " <> show entry
-      when (isFile entry.dirent && entry.name == ".gitignore") (updateGitignore entry)
+      when (isFile entry.dirent && entry.name == ".gitignore") do
+        updateIgnoreMatcherWithGitignore entry
       ignoreMatcher <- Ref.read ignoreMatcherRef
       let path = withForwardSlashes $ Path.relative cwd entry.path
       pure $ includeMatcher path && not (ignoreMatcher path)

--- a/src/Spago/Glob.purs
+++ b/src/Spago/Glob.purs
@@ -108,7 +108,7 @@ fsWalk cwd ignorePatterns includePatterns = Aff.makeAff \cb -> do
           -- Composing functions is faster, but there's the risk of blowing the stack
           -- (see #1231) - when this was introduced in #1210, every match from the
           -- gitignore file would be `or`ed to the previous matcher, which would create
-          -- a very long recursive call - in this latest iteration we are `or`ing the
+          -- a very long (linear) call chain - in this latest iteration we are `or`ing the
           -- new matchers together, then the whole thing with the previous matcher.
           -- This is still prone to stack issues, but we now have a tree so it should
           -- not be as dramatic.

--- a/test/Spago/Glob.purs
+++ b/test/Spago/Glob.purs
@@ -92,10 +92,14 @@ spec = Spec.around globTmpDir do
 
       Spec.it "is stacksafe" \p -> do
         let
-          chars = [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k" ]
-          -- 10,000-line gitignore
+          chars = [ "a", "b", "c", "d", "e", "f", "g", "h" ]
+          -- 4000-line gitignore
           words = [ \a b c d -> a <> b <> c <> d ] <*> chars <*> chars <*> chars <*> chars
           hugeGitignore = intercalate "\n" words
+        -- Write it in a few places
         FS.writeTextFile (Path.concat [ p, ".gitignore" ]) hugeGitignore
+        FS.writeTextFile (Path.concat [ p, "fruits", ".gitignore" ]) hugeGitignore
+        FS.writeTextFile (Path.concat [ p, "fruits", "left", ".gitignore" ]) hugeGitignore
+        FS.writeTextFile (Path.concat [ p, "fruits", "right", ".gitignore" ]) hugeGitignore
         a <- Glob.gitignoringGlob p [ "fruits/**/apple" ]
         Array.sort a `Assert.shouldEqual` [ "fruits/left/apple", "fruits/right/apple" ]


### PR DESCRIPTION
Fix #1242, using [purescript-core](https://github.com/purescm/purescript-core) as the benchmark.

The final patch goes back to the approach we had before #1234, where we'd compose the glob-matching functions instead of keeping a list of ignores, and recompute the matchers when needed.

The patch in #1234 was not optimised, as the matchers were being recreated for every file encountered, and optimising that in the first two commits of this PR got us down to 2x of the performance pre-1234.
That is unfortunately still not acceptable, so I reintroduced the function-composition approach, which is still prone to blowing the stack - the change here should reduce that risk, since instead of composing every line of gitignores as a separate matcher in the chain, we instead nest them in a single `or` block. That should dramatically reduce the size of the call chain.

cc @Blugatroff @cakekindel 