### PR TITLE
glob/fsWalk: early exclusion of non-matching directories

### DIFF
--- a/src/Spago/Glob.js
+++ b/src/Spago/Glob.js
@@ -1,4 +1,5 @@
 import mm from 'micromatch';
+import picomatch from 'picomatch';
 import * as fsWalk from '@nodelib/fs.walk';
 
 export const testGlob = glob => mm.matcher(glob.include, { ignore: glob.ignore });
@@ -13,3 +14,6 @@ export const fsWalkImpl = Left => Right => respond => options => path => () => {
 };
 
 export const isFile = dirent => dirent.isFile();
+
+export const scanPattern = picomatch.scan
+

--- a/src/Spago/Prelude.purs
+++ b/src/Spago/Prelude.purs
@@ -15,6 +15,7 @@ module Spago.Prelude
   , unsafeStringify
   , withBackoff'
   , withForwardSlashes
+  , isPrefix
   ) where
 
 import Spago.Core.Prelude
@@ -164,3 +165,7 @@ mkTemp = mkTemp' Nothing
 
 withForwardSlashes :: String -> String
 withForwardSlashes = String.replaceAll (Pattern "\\") (Replacement "/")
+
+isPrefix :: String.Pattern -> String -> Boolean
+isPrefix p = isJust <<< String.stripPrefix p
+


### PR DESCRIPTION
### Description of the change

For glob patterns with a fixed prefix, fsWalk will now no longer traverse directories whose contents obviously cannot match, because the directory path doesn't match the fixed prefix of the pattern.

For example, previously, globbing for `.spago/p/tailrec-6.1.0/**/*.purs` would traverse every directory (apart from those in a .gitignore, although in the case of globbing for something in .spago, that's not of much help).
Now only directories whose relative path starts with `.spago/p/tailrec-6.1.0` would be recursed into.

To determine the longest fixed prefix of a glob pattern, i used the [scan](https://www.npmjs.com/package/picomatch#scan) function from `picomatch`, which is already a dependency of micromatch.

Fix #1243 as per https://github.com/purescript/spago/issues/1243#issuecomment-2211732428

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
