### PR TITLE
Print compact stats instead of verbose when no errors or warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Other improvements:
 - Fix output truncation with `--json-errors`, many warnings and build failure (#1199)
 - Update README with info about depending on a freshly added library
 - Fixed globbing issue where `/.spago` behaves differently than `.spago` in `.gitignore`
+- Fixed empty output for `--verbose-stats` when there are no errors or warnings.
 
 ## [0.21.0] - 2023-05-04
 

--- a/src/Spago/Psa/Output.purs
+++ b/src/Spago/Psa/Output.purs
@@ -1,16 +1,17 @@
 -- A majority of this code was copied from
 -- - https://github.com/natefaubion/purescript-psa-utils
--- 
+--
 -- To fullfil license requirements
 --   Copyright © Nathan Faubion
 --   https://opensource.org/license/mit/
 module Spago.Psa.Output
-  ( buildOutput
-  , Output
+  ( Output
   , OutputStats
   , annotatedError
-  , trimPosition
+  , buildOutput
+  , initialStats
   , trimMessage
+  , trimPosition
   ) where
 
 import Prelude

--- a/src/Spago/Psa/Printer.purs
+++ b/src/Spago/Psa/Printer.purs
@@ -1,6 +1,6 @@
 -- A majority of this code was copied from
 -- - https://github.com/natefaubion/purescript-psa-utils
--- 
+--
 -- To fullfil license requirements
 --   Copyright © Nathan Faubion
 --   https://opensource.org/license/mit/
@@ -136,12 +136,15 @@ renderStats stats =
 
 renderVerboseStats :: OutputStats -> D.Doc Ansi.GraphicsParam
 renderVerboseStats stats =
-  renderStatCols
-    { col1: warningLabels <> errorLabels
-    , col2: srcWarnings <> srcErrors
-    , col3: libWarnings <> libErrors
-    , col4: allWarnings <> allErrors
-    }
+  if Array.null warnings && Array.null errors then
+    renderStats stats
+  else
+    renderStatCols
+      { col1: warningLabels <> errorLabels
+      , col2: srcWarnings <> srcErrors
+      , col3: libWarnings <> libErrors
+      , col4: allWarnings <> allErrors
+      }
   where
   warnings = Array.sort (FO.keys stats.allWarnings)
   errors = Array.sort (FO.keys stats.allErrors)

--- a/test/Spago/Unit.purs
+++ b/test/Spago/Unit.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Test.Spago.Unit.CheckInjectivity as CheckInjectivity
 import Test.Spago.Unit.FindFlags as FindFlags
+import Test.Spago.Unit.Printer as Printer
 import Test.Spec (Spec)
 import Test.Spec as Spec
 
@@ -11,3 +12,4 @@ spec :: Spec Unit
 spec = Spec.describe "unit" do
   FindFlags.spec
   CheckInjectivity.spec
+  Printer.spec

--- a/test/Spago/Unit/Printer.purs
+++ b/test/Spago/Unit/Printer.purs
@@ -1,0 +1,25 @@
+module Test.Spago.Unit.Printer where
+
+import Prelude
+
+import Data.String (joinWith)
+import Dodo as Dodo
+import Spago.Psa.Output (initialStats)
+import Spago.Psa.Printer (renderVerboseStats)
+import Test.Prelude (shouldEqual)
+import Test.Spec (Spec)
+import Test.Spec as Spec
+
+spec :: Spec Unit
+spec = do
+  Spec.describe "renderVerboseStats" do
+    Spec.it "renders regular stats with all zeroes when there are no errors or warnings" do
+      printDoc (renderVerboseStats initialStats) `shouldEqual`
+        joinWith "\n"
+        [ "           Src   Lib   All"
+        , "Warnings     0     0     0"
+        , "Errors       0     0     0"
+        ]
+
+  where
+    printDoc = Dodo.print Dodo.plainText Dodo.twoSpaces


### PR DESCRIPTION
### Description of the change

Fixes #1195 

When there are no errors or warnings, we're just delegating to `renderStats` to print all zeroes.

![image](https://github.com/user-attachments/assets/e5a35617-780d-4d73-82bf-f098171c4bbf)

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)