### PR TITLE
`spago repl` writes a `.purs-repl` file unless already there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Other improvements:
 - Update README with info about depending on a freshly added library
 - Fixed globbing issue where `/.spago` behaves differently than `.spago` in `.gitignore`
 - Fixed empty output for `--verbose-stats` when there are no errors or warnings.
+- `spago repl` now writes a `.purs-repl` file, unless already there, containing `import Prelude`.
 
 ## [0.21.0] - 2023-05-04
 

--- a/core/src/FS.purs
+++ b/core/src/FS.purs
@@ -1,5 +1,9 @@
 module Spago.FS
   ( chmod
+  , copyFile
+  , copyFileSync
+  , copyTree
+  , unlink
   , ensureFileSync
   , exists
   , getInBetweenPaths
@@ -7,9 +11,6 @@ module Spago.FS
   , ls
   , mkdirp
   , moveSync
-  , copyFileSync
-  , copyFile
-  , copyTree
   , readJsonFile
   , readTextFile
   , readYamlDocFile
@@ -68,6 +69,9 @@ ensureFileSync file = liftEffect $ ensureFileSyncImpl file
 
 exists :: forall m. MonadEffect m => String -> m Boolean
 exists = liftEffect <<< FS.Sync.exists
+
+unlink :: ∀ m. MonadAff m => String -> m Unit
+unlink = liftAff <<< FS.Aff.unlink
 
 writeTextFile :: forall m. MonadAff m => FilePath -> String -> m Unit
 writeTextFile path text = liftAff $ FS.Aff.writeTextFile UTF8 path text

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -1,13 +1,14 @@
 module Spago.Command.Init
-  ( run
-  , InitOptions
-  , srcMainTemplate
-  , testMainTemplate
-  , defaultConfig
-  , DefaultConfigOptions(..)
+  ( DefaultConfigOptions(..)
   , DefaultConfigPackageOptions
   , DefaultConfigWorkspaceOptions
+  , InitOptions
+  , defaultConfig
   , defaultConfig'
+  , pursReplFile
+  , run
+  , srcMainTemplate
+  , testMainTemplate
   ) where
 
 import Spago.Prelude
@@ -31,7 +32,7 @@ type InitOptions =
 
 -- TODO run git init? Is that desirable?
 
-run :: InitOptions -> Spago (RegistryEnv _) Config
+run :: ∀ a. InitOptions -> Spago (RegistryEnv a) Config
 run opts = do
   logInfo "Initializing a new project..."
 
@@ -71,7 +72,7 @@ run opts = do
 
   copyIfNotExists ".gitignore" gitignoreTemplate
 
-  copyIfNotExists ".purs-repl" pursReplTemplate
+  copyIfNotExists pursReplFile.name pursReplFile.content
 
   pure config
 
@@ -227,11 +228,8 @@ generated-docs/
 .spago
 """
 
-pursReplTemplate :: String
-pursReplTemplate =
-  """
-import Prelude
-"""
+pursReplFile :: { name :: String, content :: String }
+pursReplFile = { name: ".purs-repl", content: "import Prelude\n" }
 
 -- ERROR TEXTS -----------------------------------------------------------------
 

--- a/src/Spago/Command/Repl.purs
+++ b/src/Spago/Command/Repl.purs
@@ -8,7 +8,9 @@ import Spago.Prelude
 import Data.Map as Map
 import Spago.Command.Build as Build
 import Spago.Command.Fetch as Fetch
+import Spago.Command.Init (pursReplFile)
 import Spago.Config (PackageMap, WorkspacePackage)
+import Spago.FS as FS
 import Spago.Purs (Purs)
 import Spago.Purs as Purs
 
@@ -23,9 +25,12 @@ type ReplEnv a =
   | a
   }
 
-run :: Spago (ReplEnv _) Unit
+run :: ∀ a. Spago (ReplEnv a) Unit
 run = do
   { dependencies, pursArgs, selected, depsOnly, supportPackage } <- ask
+
+  unlessM (FS.exists pursReplFile.name) $
+    FS.writeTextFile pursReplFile.name pursReplFile.content
 
   let
     allDependencies = Map.unionWith (\l _ -> l) supportPackage $ Fetch.toAllDependencies dependencies

--- a/test/Spago.purs
+++ b/test/Spago.purs
@@ -20,6 +20,7 @@ import Test.Spago.Lock as Lock
 import Test.Spago.Ls as Ls
 import Test.Spago.Publish as Publish
 import Test.Spago.Registry as Registry
+import Test.Spago.Repl as Repl
 import Test.Spago.Run as Run
 import Test.Spago.Sources as Sources
 import Test.Spago.Test as Test
@@ -47,6 +48,7 @@ main = Aff.launchAff_ $ void $ un Identity $ Spec.Runner.runSpecT testConfig [ S
     Uninstall.spec
     Ls.spec
     Build.spec
+    Repl.spec
     Run.spec
     Test.spec
     Bundle.spec

--- a/test/Spago/Build.purs
+++ b/test/Spago/Build.purs
@@ -43,7 +43,7 @@ spec = Spec.around withTempDir do
 
     Spec.it "can build with a local custom package set" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
-      FSA.unlink "spago.yaml"
+      FS.unlink "spago.yaml"
       FS.copyFileSync { src: fixture "local-package-set-config.yaml", dst: "spago.yaml" }
       FS.copyFileSync { src: fixture "local-package-set.json", dst: "local-package-set.json" }
       spago [ "build" ] >>= shouldBeSuccess
@@ -53,7 +53,7 @@ spec = Spec.around withTempDir do
       FS.mkdirp "subdir"
       liftEffect $ Process.chdir "subdir"
       spago [ "init" ] >>= shouldBeSuccess
-      FSA.unlink "spago.yaml"
+      FS.unlink "spago.yaml"
       FS.copyFileSync { src: fixture "local-package-set-config2.yaml", dst: "spago.yaml" }
       spago [ "build" ] >>= shouldBeSuccess
 
@@ -78,7 +78,7 @@ spec = Spec.around withTempDir do
     Spec.it "--strict causes build to fail if there are warnings" \{ spago, fixture } -> do
       spago [ "init" ] >>= shouldBeSuccess
       let srcMain = Path.concat [ "src", "Main.purs" ]
-      FSA.unlink srcMain
+      FS.unlink srcMain
       FS.copyFile
         { src: fixture "check-strict.purs"
         , dst: srcMain
@@ -90,12 +90,12 @@ spec = Spec.around withTempDir do
       let
         srcMain = Path.concat [ "src", "Main.purs" ]
         spagoYaml = "spago.yaml"
-      FSA.unlink srcMain
+      FS.unlink srcMain
       FS.copyFile
         { src: fixture "check-strict.purs"
         , dst: srcMain
         }
-      FSA.unlink spagoYaml
+      FS.unlink spagoYaml
       FS.copyFile
         { src: fixture "check-strict.yaml"
         , dst: spagoYaml

--- a/test/Spago/Install.purs
+++ b/test/Spago/Install.purs
@@ -49,7 +49,7 @@ spec = Spec.around withTempDir do
     Spec.it "adds test dependencies to the config file when the test section does not exist" \{ spago, fixture } -> do
       spago [ "init", "--name", "aaa", "--package-set", "29.3.0" ] >>= shouldBeSuccess
       let spagoYaml = "spago.yaml"
-      FSA.unlink spagoYaml
+      FS.unlink spagoYaml
       FS.copyFile
         { src: fixture "no-test-section.yaml"
         , dst: spagoYaml

--- a/test/Spago/Publish.purs
+++ b/test/Spago/Publish.purs
@@ -2,7 +2,6 @@ module Test.Spago.Publish (spec) where
 
 import Test.Prelude
 
-import Node.FS.Aff as FSA
 import Node.Platform as Platform
 import Node.Process as Process
 import Spago.Cmd as Cmd
@@ -34,7 +33,7 @@ spec = Spec.around withTempDir do
 
     Spec.it "fails if the module is called Main" \{ spago, fixture } -> do
       spago [ "init", "--name", "aaaa" ] >>= shouldBeSuccess
-      FSA.unlink "spago.yaml"
+      FS.unlink "spago.yaml"
       FS.copyFile { src: fixture "spago-publish.yaml", dst: "spago.yaml" }
       spago [ "build" ] >>= shouldBeSuccess
       doTheGitThing

--- a/test/Spago/Repl.purs
+++ b/test/Spago/Repl.purs
@@ -1,0 +1,25 @@
+module Test.Spago.Repl where
+
+import Test.Prelude
+
+import Spago.FS as FS
+import Test.Spec (Spec)
+import Test.Spec as Spec
+
+spec :: Spec Unit
+spec = Spec.around withTempDir do
+  Spec.describe "repl" do
+
+    Spec.it "writes .purs-repl if not there" \{ spago, spago' } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      FS.readTextFile ".purs-repl" >>= shouldEqual "import Prelude\n"
+
+      FS.unlink ".purs-repl"
+      spago' (StdinWrite ":q") [ "repl" ] >>= shouldBeSuccess
+      FS.readTextFile ".purs-repl" >>= shouldEqual "import Prelude\n"
+
+    Spec.it "does not write .purs-repl if already there" \{ spago, spago' } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      FS.writeTextFile ".purs-repl" "import Data.Maybe\n"
+      spago' (StdinWrite ":q") [ "repl" ] >>= shouldBeSuccess
+      FS.readTextFile ".purs-repl" >>= shouldEqual "import Data.Maybe\n"


### PR DESCRIPTION
### Description of the change

Fixes #1192

If there is not already a `.purs-repl` in the current directory, `spago repl` will write a new one. 
The template is shared with `spago init` to avoid divergence in the future.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)
