### PR TITLE
Add --package-set option to spago upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Other improvements:
 - Update README with info about depending on a freshly added library
 - Fixed globbing issue where `/.spago` behaves differently than `.spago` in `.gitignore`
 - Fixed empty output for `--verbose-stats` when there are no errors or warnings.
+- Added support for `--package-set` options for `spago upgrade`.
 
 ## [0.21.0] - 2023-05-04
 

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -184,7 +184,9 @@ type PublishArgs =
   { selectedPackage :: Maybe String
   }
 
-type UpgradeArgs = {}
+type UpgradeArgs =
+  { setVersion :: Maybe String
+  }
 
 data SpagoCmd a = SpagoCmd GlobalArgs (Command a)
 
@@ -233,7 +235,7 @@ argParser =
     , commandParser "sources" (Sources <$> sourcesArgsParser) "List all the source paths (globs) for the dependencies of the project"
     , commandParser "repl" (Repl <$> replArgsParser) "Start a REPL"
     , commandParser "publish" (Publish <$> publishArgsParser) "Publish a package"
-    , commandParser "upgrade" (Upgrade <$> pure {}) "Upgrade to the latest package set, or to the latest versions of Registry packages"
+    , commandParser "upgrade" (Upgrade <$> upgradeArgsParser) "Upgrade to the latest package set, or to the latest versions of Registry packages"
     , commandParser "docs" (Docs <$> docsArgsParser) "Generate docs for the project and its dependencies"
     , O.command "registry"
         ( O.info
@@ -369,6 +371,11 @@ runArgsParser = Optparse.fromRecord
   , strict: Flags.strict
   , statVerbosity: Flags.statVerbosity
   , pure: Flags.pure
+  }
+
+upgradeArgsParser :: Parser UpgradeArgs
+upgradeArgsParser = Optparse.fromRecord
+  { setVersion: Flags.maybeSetVersion
   }
 
 testArgsParser :: Parser TestArgs
@@ -545,9 +552,7 @@ main = do
                 , Log.indent2 $ toDoc err
                 ]
               Right p -> pure p
-            setVersion <- for args.setVersion $ parseLenientVersion >>> case _ of
-              Left err -> die [ "Could not parse provided set version. Error:", show err ]
-              Right v -> pure v
+            setVersion <- parseSetVersion args.setVersion
             logDebug [ "Got packageName and setVersion:", PackageName.print packageName, unsafeStringify setVersion ]
             let initOpts = { packageName, setVersion, useSolver }
             -- Fetch the registry here so we can select the right package set later
@@ -675,9 +680,10 @@ main = do
             dependencies <- runSpago env (Fetch.run fetchOpts)
             docsEnv <- runSpago env (mkDocsEnv args dependencies)
             runSpago docsEnv Docs.run
-          Upgrade _args -> do
+          Upgrade args -> do
+            setVersion <- parseSetVersion args.setVersion
             { env } <- mkFetchEnv { packages: mempty, selectedPackage: Nothing, pure: false, ensureRanges: false, testDeps: false, isRepl: false, migrateConfig, offline }
-            runSpago env Upgrade.run
+            runSpago env $ Upgrade.run { setVersion }
           -- TODO: add selected to graph commands
           GraphModules args -> do
             { env, fetchOpts } <- mkFetchEnv { packages: mempty, selectedPackage: Nothing, pure: false, ensureRanges: false, testDeps: false, isRepl: false, migrateConfig, offline }
@@ -705,6 +711,11 @@ main = do
           LogVerbose
         else LogNormal
     pure { color, verbosity, startingTime }
+
+  parseSetVersion maybeVersion =
+    for maybeVersion $ parseLenientVersion >>> case _ of
+      Left err -> die [ "Could not parse provided set version. Error:", show err ]
+      Right v -> pure v
 
 mkBundleEnv :: forall a. BundleArgs -> Spago (Fetch.FetchEnv a) (Bundle.BundleEnv ())
 mkBundleEnv bundleArgs = do
@@ -993,7 +1004,7 @@ mkLsEnv dependencies = do
               ]
   pure { logOptions, workspace, dependencies, selected }
 
-mkDocsEnv :: DocsArgs -> Fetch.PackageTransitiveDeps -> Spago (Fetch.FetchEnv _) (Docs.DocsEnv _)
+mkDocsEnv :: ∀ a. DocsArgs -> Fetch.PackageTransitiveDeps -> Spago (Fetch.FetchEnv a) (Docs.DocsEnv ())
 mkDocsEnv args dependencies = do
   { logOptions, workspace } <- ask
   purs <- Purs.getPurs

--- a/src/Spago/Command/Upgrade.purs
+++ b/src/Spago/Command/Upgrade.purs
@@ -8,16 +8,23 @@ import Spago.Config as Config
 import Spago.Core.Config as Core
 import Spago.Registry as Registry
 
-run :: forall a. Spago (FetchEnv a) Unit
-run = do
+type UpgradeArgs =
+  { setVersion :: Maybe Version
+  }
+
+run :: ∀ a. UpgradeArgs -> Spago (FetchEnv a) Unit
+run args = do
   { workspace } <- ask
   case workspace.workspaceConfig.packageSet of
     Just (Core.SetFromRegistry { registry: currentPackageSet }) -> do
-      latestPackageSet <- Registry.findPackageSet Nothing
+      latestPackageSet <- Registry.findPackageSet args.setVersion
+
+      let whichVersion = args.setVersion # maybe "latest" (const "specified")
+
       case latestPackageSet <= currentPackageSet of
-        true -> logSuccess "Nothing to upgrade, you already have the latest package set."
+        true -> logSuccess $ "Nothing to upgrade, you already have the " <> whichVersion <> " package set."
         false -> do
-          logInfo $ "Upgrading the package set to the latest version: " <> Version.print latestPackageSet
+          logInfo $ "Upgrading the package set to the " <> whichVersion <> " version: " <> Version.print latestPackageSet
           Config.setPackageSetVersionInConfig workspace.doc latestPackageSet
           logSuccess "Upgrade successful!"
     Just _ -> die "This command is not yet implemented for projects using a custom package set."

--- a/test/Spago/Upgrade.purs
+++ b/test/Spago/Upgrade.purs
@@ -19,10 +19,29 @@ spec = Spec.around withTempDir do
       spago [ "upgrade" ] >>= shouldBeSuccess
       -- we can't just check a fixture here, as there are new package set versions all the time.
       -- so we read the config file, and check that the package set version is more recent than the one we started with
-      let initialVersion = mkVersion "20.0.1"
-      startingTime <- liftEffect $ Now.now
-      maybeConfig <- runSpago { logOptions: { color: false, verbosity: LogQuiet, startingTime } } (Config.readConfig "spago.yaml")
-      case maybeConfig of
-        Right { yaml: { workspace: Just { packageSet: Just (SetFromRegistry { registry }) } } } | registry > initialVersion -> pure unit
-        Right { yaml: c } -> Assert.fail $ "Could not upgrade the package set, config: " <> printJson Config.configCodec c
-        Left err -> Assert.fail $ "Could not read config: " <> show err
+      assertExpectedVersion
+        { check: (_ > mkVersion "20.0.1")
+        , error: "Could not upgrade the package set."
+        }
+
+    Spec.it "allows to specify package set version" \{ spago } -> do
+      spago [ "init", "--name", "aaa", "--package-set", "20.0.0" ] >>= shouldBeSuccess
+      assertExpectedVersion
+        { check: (_ == mkVersion "20.0.0")
+        , error: "Could not init with package set 20.0.0."
+        }
+
+      spago [ "upgrade", "--package-set", "20.0.1" ] >>= shouldBeSuccess
+      assertExpectedVersion
+        { check: (_ == mkVersion "20.0.1")
+        , error: "Could not upgrade the package set to 20.0.1."
+        }
+
+    where
+      assertExpectedVersion { check, error } = do
+        startingTime <- liftEffect $ Now.now
+        maybeConfig <- runSpago { logOptions: { color: false, verbosity: LogQuiet, startingTime } } (Config.readConfig "spago.yaml")
+        case maybeConfig of
+          Right { yaml: { workspace: Just { packageSet: Just (SetFromRegistry { registry }) } } } | check registry -> pure unit
+          Right { yaml: c } -> Assert.fail $ error <> " Config: " <> printJson Config.configCodec c
+          Left err -> Assert.fail $ "Could not read config: " <> show err


### PR DESCRIPTION
### Description of the change

Fixes #1191

```
 λ npx spago upgrade --package-set 55.1.0

<snip>
Upgrading the package set to the specified version: 55.1.0


 λ npx spago upgrade --package-set 55.2.0

<snip>
Upgrading the package set to the specified version: 55.2.0


 λ npx spago upgrade --package-set 55.2.0

<snip>
✅ Nothing to upgrade, you already have the specified package set.


 λ npx spago upgrade

<snip>
Upgrading the package set to the latest version: 55.3.0


 λ npx spago upgrade

<snip>
✅ Nothing to upgrade, you already have the latest package set.


 λ npx spago upgrade --help

<snip>
  --package-set ARG        Optional package set version to be used instead of
                           the latest one
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
    - It was already there: https://github.com/fsoikin/spago/blob/master/README.md/#upgrading-packages-and-the-package-set
- [x] Added a test for the contribution (if applicable)