### PR TITLE
spago publish verifies that the publish location matches one of the current repo's remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Other improvements:
 - Added support for `--package-set` options for `spago upgrade`.
 - `spago repl` now writes a `.purs-repl` file, unless already there, containing `import Prelude`.
 - Added typo suggestions upon failing to find a package by name.
+- `spago publish` now checks that the publish location matches one of the remotes in the current Git repository.
 
 ## [0.21.0] - 2023-05-04
 

--- a/test-fixtures/publish-invalid-location.txt
+++ b/test-fixtures/publish-invalid-location.txt
@@ -1,0 +1,18 @@
+Reading Spago workspace configuration...
+
+✅ Selecting package to build: aaa
+
+Downloading dependencies...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✅ Build succeeded.
+
+Your package "aaa" is not ready for publishing yet, encountered 1 error:
+
+
+❌ The location specified in the manifest file
+({"githubOwner":"purescript","githubRepo":"aaa"})
+ is not one of the remotes in the git repository.

--- a/test/Spago/Errors.purs
+++ b/test/Spago/Errors.purs
@@ -4,12 +4,10 @@ import Test.Prelude
 
 import Data.Array as Array
 import Data.Foldable (traverse_)
-import Data.String (joinWith)
 import Data.String as String
 import Spago.FS as FS
 import Test.Spec (Spec)
 import Test.Spec as Spec
-import Test.Spec.Assertions.String (shouldContain)
 
 spec :: Spec Unit
 spec = Spec.around withTempDir do

--- a/test/Spago/Unit.purs
+++ b/test/Spago/Unit.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Test.Spago.Unit.CheckInjectivity as CheckInjectivity
 import Test.Spago.Unit.FindFlags as FindFlags
+import Test.Spago.Unit.Git as Git
 import Test.Spago.Unit.Printer as Printer
 import Test.Spec (Spec)
 import Test.Spec as Spec
@@ -13,3 +14,4 @@ spec = Spec.describe "unit" do
   FindFlags.spec
   CheckInjectivity.spec
   Printer.spec
+  Git.spec

--- a/test/Spago/Unit/Git.purs
+++ b/test/Spago/Unit/Git.purs
@@ -1,0 +1,28 @@
+module Test.Spago.Unit.Git where
+
+import Prelude
+
+import Spago.Git (parseRemote)
+import Test.Prelude (Maybe(..), shouldEqual)
+import Test.Spec (Spec)
+import Test.Spec as Spec
+
+spec :: Spec Unit
+spec = do
+  Spec.describe "Git" do
+    Spec.describe "parseRemote" do
+
+      Spec.it "parses a remote with a git protocol" do
+        parseRemote "origin\tgit@github.com:foo/bar.git (fetch)"
+          `shouldEqual` Just { name: "origin", url: "git@github.com:foo/bar.git", owner: "foo", repo: "bar" }
+
+      Spec.it "parses a remote with an https protocol" do
+        parseRemote "origin\thttps://github.com/foo/bar.git (push)"
+          `shouldEqual` Just { name: "origin", url: "https://github.com/foo/bar.git", owner: "foo", repo: "bar" }
+
+      Spec.it "rejects malformed remotes" do
+        parseRemote "origin\tgit@github.com:foo/bar.git" `shouldEqual` Nothing
+        parseRemote "origin\tgit@github.com:foo/bar (push)" `shouldEqual` Nothing
+        parseRemote "origin git@github.com:foo/bar.git (fetch)" `shouldEqual` Nothing
+        parseRemote "origin\tgit@github.com:foo.git (push)" `shouldEqual` Nothing
+        parseRemote "origin\thttps://foo.com/bar.git (push)" `shouldEqual` Nothing


### PR DESCRIPTION
### Description of the change

Fixes #1179

Rather than checking that the repository exists on GitHub, I opted to proxy that by checking that the publish location matches one of the remotes in the current local repo. There are several reasons to do this:
1. Works in offline mode.
2. Works for (potentially) non-GitHub repositories.
3. One fewer network requests.
4. Actually a better check: even if the publish location does exist, it may be a completely different, unrelated repository, which may happen, for example, when copy&pasting config to bootstrap a new project. Checking against local remotes makes it more likely that the publish location is actually location of this project.
5. An escape hatch in case of bugs. If something doesn't work, you can shoehorn it by adding a dummy remote with the right names.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)
