### PR TITLE
fix: error "Could not parse any remotes from the output of `git remote --verbose`."

### DIFF
--- a/src/Spago/Git.purs
+++ b/src/Spago/Git.purs
@@ -204,13 +204,14 @@ getGit = do
 
 parseRemote :: String -> Maybe Remote
 parseRemote = \line ->
-  case String.split (Pattern "\t") line of
-    [ name, secondPart ]
-      | [ url, _ ] <- String.split (Pattern " ") secondPart
-      , Just [ _, _, Just owner, Just repo ] <- NEA.toArray <$> Regex.match gitUrlRegex url ->
+  case Regex.split tabOrSpaceRegex line of
+    [ name, url, _ ]
+      | Just [ _, _, _, Just owner, Just repo ] <- NEA.toArray <$> Regex.match gitUrlRegex url ->
           Just { name, url, owner, repo }
     _ ->
       Nothing
   where
+  tabOrSpaceRegex = unsafePartial $ fromJust $ hush $
+    Regex.regex "\\s+" mempty
   gitUrlRegex = unsafePartial $ fromJust $ hush $
-    Regex.regex "^(.+@.+:|https?:\\/\\/.+\\/)(.*)\\/(.+)\\.git$" mempty
+    Regex.regex "^((ssh:\\/\\/)?[^@]+@[^:]+[:\\/]|https?:\\/\\/[^\\/]+\\/)(.*)\\/(.+)\\.git$" mempty

--- a/test/Spago/Unit/Git.purs
+++ b/test/Spago/Unit/Git.purs
@@ -15,14 +15,30 @@ spec = do
       Spec.it "parses a remote with a git protocol" do
         parseRemote "origin\tgit@github.com:foo/bar.git (fetch)"
           `shouldEqual` Just { name: "origin", url: "git@github.com:foo/bar.git", owner: "foo", repo: "bar" }
+        parseRemote "origin  git@github.com:foo/bar.git (fetch)"
+          `shouldEqual` Just { name: "origin", url: "git@github.com:foo/bar.git", owner: "foo", repo: "bar" }
 
       Spec.it "parses a remote with an https protocol" do
         parseRemote "origin\thttps://github.com/foo/bar.git (push)"
           `shouldEqual` Just { name: "origin", url: "https://github.com/foo/bar.git", owner: "foo", repo: "bar" }
+        parseRemote "origin  https://github.com/foo/bar.git (push)"
+          `shouldEqual` Just { name: "origin", url: "https://github.com/foo/bar.git", owner: "foo", repo: "bar" }
+
+      Spec.it "parses a remote with an ssh protocol" do
+        parseRemote "origin\tssh://git@github.com/foo/bar.git (push)"
+          `shouldEqual` Just { name: "origin", url: "ssh://git@github.com/foo/bar.git", owner: "foo", repo: "bar" }
+        parseRemote "origin  ssh://git@github.com/foo/bar.git (push)"
+          `shouldEqual` Just { name: "origin", url: "ssh://git@github.com/foo/bar.git", owner: "foo", repo: "bar" }
 
       Spec.it "rejects malformed remotes" do
         parseRemote "origin\tgit@github.com:foo/bar.git" `shouldEqual` Nothing
+        parseRemote "origin  git@github.com:foo/bar.git" `shouldEqual` Nothing
+
         parseRemote "origin\tgit@github.com:foo/bar (push)" `shouldEqual` Nothing
-        parseRemote "origin git@github.com:foo/bar.git (fetch)" `shouldEqual` Nothing
+        parseRemote "origin  git@github.com:foo/bar (push)" `shouldEqual` Nothing
+
         parseRemote "origin\tgit@github.com:foo.git (push)" `shouldEqual` Nothing
+        parseRemote "origin  git@github.com:foo.git (push)" `shouldEqual` Nothing
+
         parseRemote "origin\thttps://foo.com/bar.git (push)" `shouldEqual` Nothing
+        parseRemote "origin  https://foo.com/bar.git (push)" `shouldEqual` Nothing


### PR DESCRIPTION
### Description of the change

now it handles spaces too, not only tabs

also `ssh://`

# Error was

```sh
$ ~/projects/spago/bin/index.dev.js publish -p open-drawing --verbose 
....
✘ Could not parse any remotes from the output of `git remote --verbose`.

$ git remote --verbose
origin  ssh://git@github.com/purescript-open-community/purescript-open-drawing.git (fetch)
origin  ssh://git@github.com/purescript-open-community/purescript-open-drawing.git (push)
```



### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
