### PR TITLE
In PSA output label warnings and errors as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Other improvements:
   cached locally.
 - `spago publish` now allows to publish a package with some test (but only
   test!) dependencies not present in the registry.
+- errors and warnings are now explicitly labeled as "ERR" and "WARN" in Spago
+  build output.
 
 ## [0.21.0] - 2023-05-04
 

--- a/src/Spago/Psa/Printer.purs
+++ b/src/Spago/Psa/Printer.purs
@@ -5,9 +5,7 @@
 --   Copyright © Nathan Faubion
 --   https://opensource.org/license/mit/
 module Spago.Psa.Printer
-  ( renderWarning
-  , renderError
-  , renderStats
+  ( renderStats
   , renderVerboseStats
   , printDefaultOutputToErr
   , printJsonOutputToOut
@@ -50,11 +48,11 @@ printJsonOutputToOut output = do
 printDefaultOutputToErr :: PsaArgs -> Output -> Effect Unit
 printDefaultOutputToErr options output = do
   forWithIndex_ output.warnings \i warning -> do
-    Console.error $ printDoc (renderWarning lenWarnings (i + 1) warning)
+    Console.error $ printDoc (renderCitation Warn lenWarnings (i + 1) warning)
     Console.error ""
 
   forWithIndex_ output.errors \i error -> do
-    Console.error $ printDoc (renderError lenErrors (i + 1) error)
+    Console.error $ printDoc (renderCitation Err lenErrors (i + 1) error)
     Console.error ""
 
   Console.error $ printDoc (renderStats' output.stats)
@@ -70,17 +68,21 @@ printDefaultOutputToErr options output = do
     Core.CompactStats -> renderStats
     Core.VerboseStats -> renderVerboseStats
 
-renderWarning :: Int -> Int -> PsaAnnotedError -> D.Doc Ansi.GraphicsParam
-renderWarning = renderWrapper Ansi.BrightYellow
+data Citation = Warn | Err
 
-renderError :: Int -> Int -> PsaAnnotedError -> D.Doc Ansi.GraphicsParam
-renderError = renderWrapper Ansi.BrightRed
+citationColor :: Citation -> Ansi.Color
+citationColor Warn = Ansi.BrightYellow
+citationColor Err = Ansi.BrightRed
 
-renderWrapper :: Ansi.Color -> Int -> Int -> PsaAnnotedError -> D.Doc Ansi.GraphicsParam
-renderWrapper color total index { error, path, position, source, message } =
+citationLabel :: Citation -> String
+citationLabel Warn = "WARN"
+citationLabel Err = "ERR"
+
+renderCitation :: Citation -> Int -> Int -> PsaAnnotedError -> D.Doc Ansi.GraphicsParam
+renderCitation cit total index { error, path, position, source, message } =
   D.foldWithSeparator (D.break <> D.break)
     [ D.words $
-        [ renderStatus color total index error.errorCode
+        [ renderStatus cit total index error.errorCode
         , renderPath path error.moduleName <> foldMap renderPosition position
         ]
     , D.indent $ D.lines
@@ -92,9 +94,11 @@ renderWrapper color total index { error, path, position, source, message } =
 toLines :: String -> D.Doc Ansi.GraphicsParam
 toLines = D.lines <<< map D.text <<< Str.split (Str.Pattern "\n")
 
-renderStatus :: Ansi.Color -> Int -> Int -> String -> D.Doc Ansi.GraphicsParam
-renderStatus color total index code =
-  DA.foreground color $ D.text $ "[" <> show index <> "/" <> show total <> " " <> code <> "]"
+renderStatus :: Citation -> Int -> Int -> String -> D.Doc Ansi.GraphicsParam
+renderStatus cit total index code =
+  DA.foreground (citationColor cit)
+    $ D.text
+    $ "[" <> citationLabel cit <> " " <> show index <> "/" <> show total <> " " <> code <> "]"
 
 renderModuleName :: Maybe String -> D.Doc Ansi.GraphicsParam
 renderModuleName Nothing = DA.dim $ D.text "(unknown module)"

--- a/test-fixtures/build/1148-warnings-diff-errors/errors/expected-stderr.txt
+++ b/test-fixtures/build/1148-warnings-diff-errors/errors/expected-stderr.txt
@@ -1,0 +1,43 @@
+Reading Spago workspace configuration...
+
+✓ Selecting package to build: foo
+
+Downloading dependencies...
+Building...
+[1 of 2] Compiling Foo
+[2 of 2] Compiling Main
+[ERR 1/2 TypesDoNotUnify] src/Foo.purs:4:5
+
+  4  x = "nope"
+         ^^^^^^
+
+  Could not match type
+    String
+  with type
+    Int
+  while checking that type String
+    is at least as general as type Int
+  while checking that expression "nope"
+    has type Int
+  in value declaration x
+
+[ERR 2/2 TypesDoNotUnify] src/Main.purs:10:7
+
+  10    log 42
+            ^^
+
+  Could not match type
+    Int
+  with type
+    String
+  while checking that type Int
+    is at least as general as type String
+  while checking that expression 42
+    has type String
+  in value declaration main
+
+           Src   Lib   All
+Warnings     0     0     0
+Errors       2     0     2
+
+✘ Failed to build.

--- a/test-fixtures/build/1148-warnings-diff-errors/errors/spago.yaml
+++ b/test-fixtures/build/1148-warnings-diff-errors/errors/spago.yaml
@@ -1,0 +1,10 @@
+package:
+  name: foo
+  dependencies:
+    - console
+    - effect
+    - prelude
+
+workspace:
+  packageSet:
+    registry: 41.5.0

--- a/test-fixtures/build/1148-warnings-diff-errors/errors/src/Foo.purs
+++ b/test-fixtures/build/1148-warnings-diff-errors/errors/src/Foo.purs
@@ -1,0 +1,4 @@
+module Foo where
+
+x :: Int
+x = "nope"

--- a/test-fixtures/build/1148-warnings-diff-errors/errors/src/Main.purs
+++ b/test-fixtures/build/1148-warnings-diff-errors/errors/src/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+
+import Effect
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  log 42
+  pure unit

--- a/test-fixtures/build/1148-warnings-diff-errors/warnings/expected-stderr.txt
+++ b/test-fixtures/build/1148-warnings-diff-errors/warnings/expected-stderr.txt
@@ -1,0 +1,43 @@
+Reading Spago workspace configuration...
+
+✓ Selecting package to build: foo
+
+Downloading dependencies...
+Building...
+[1 of 1] Compiling Main
+[WARN 1/4 ImplicitImport] src/Main.purs:3:1
+
+  3  import Prelude
+     ^^^^^^^^^^^^^^
+
+  Module Prelude has unspecified imports, consider using the explicit form:
+    import Prelude (Unit, pure, unit)
+
+[WARN 2/4 ImplicitImport] src/Main.purs:5:1
+
+  5  import Effect
+     ^^^^^^^^^^^^^
+
+  Module Effect has unspecified imports, consider using the explicit form:
+    import Effect (Effect)
+
+[WARN 3/4 UnusedImport] src/Main.purs:6:1
+
+  6  import Effect.Console (log)
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  The import of Effect.Console is redundant
+
+[WARN 4/4 UnusedName] src/Main.purs:10:7
+
+  10    let unusedVar = 1
+            ^^^^^^^^^^^^^
+
+  Name unusedVar was introduced but not used.
+  in value declaration main
+
+           Src   Lib   All
+Warnings     4     0     4
+Errors       0     0     0
+
+✓ Build succeeded.

--- a/test-fixtures/build/1148-warnings-diff-errors/warnings/spago.yaml
+++ b/test-fixtures/build/1148-warnings-diff-errors/warnings/spago.yaml
@@ -1,0 +1,10 @@
+package:
+  name: foo
+  dependencies:
+    - console
+    - effect
+    - prelude
+
+workspace:
+  packageSet:
+    registry: 41.5.0

--- a/test-fixtures/build/1148-warnings-diff-errors/warnings/src/Main.purs
+++ b/test-fixtures/build/1148-warnings-diff-errors/warnings/src/Main.purs
@@ -1,0 +1,11 @@
+module Main where
+
+import Prelude
+
+import Effect
+import Effect.Console (log)
+
+main :: Effect Unit
+main = do
+  let unusedVar = 1
+  pure unit

--- a/test/Spago/Build.purs
+++ b/test/Spago/Build.purs
@@ -211,6 +211,17 @@ spec = Spec.around withTempDir do
       spago [ "build" ] >>= shouldBeSuccessErr (fixture "build/migrate-config/migrated-output.txt")
       checkFixture "spago.yaml" (fixture "build/migrate-config/migrated-spago.yaml")
 
+    Spec.it "#1148: outputs errors and warnings after build" \{ spago, fixture } -> do
+      FS.copyTree { src: fixture "build/1148-warnings-diff-errors", dst: "." }
+
+      liftEffect $ Process.chdir "errors"
+      spago [ "install" ] >>= shouldBeSuccess
+      spago [ "build" ] >>= shouldBeFailureErr (fixture "build/1148-warnings-diff-errors/errors/expected-stderr.txt")
+
+      liftEffect $ Process.chdir "../warnings"
+      spago [ "install" ] >>= shouldBeSuccess
+      spago [ "build" ] >>= shouldBeSuccessErr (fixture "build/1148-warnings-diff-errors/warnings/expected-stderr.txt")
+
     Pedantic.spec
 
     Monorepo.spec


### PR DESCRIPTION
### Description of the change

Fixes #1148 

The outputs now look like:

```
[WARN 1/4 ImplicitImport] src/Main.purs:3:1

[ERR 1/2 TypesDoNotUnify] src/Foo.purs:4:5
```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)