### PR TITLE
New 'spago init --subpackage foo' option to initialize a sub-project within current workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Other improvements:
   Spago on different platforms.
 - when encountering a mistyped option for a command, Spago will show help for
   that command, not root help.
+- a new `spago init --subpackage foo` option to initialize a sub-project in the
+  current workspace.
 
 ## [0.21.0] - 2023-05-04
 

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -7,7 +7,9 @@ import Data.List as List
 import Options.Applicative (FlagFields, Mod, Parser)
 import Options.Applicative as O
 import Options.Applicative.Types as OT
+import Spago.Command.Init as Init
 import Spago.Core.Config as Core
+import Spago.Prelude as Prelude
 
 flagMaybe ∷ ∀ (a ∷ Type). a -> Mod FlagFields (Maybe a) -> Parser (Maybe a)
 flagMaybe a mod = O.flag Nothing (Just a) mod
@@ -300,6 +302,19 @@ maybePackageName =
       ( O.long "name"
           <> O.help "Optional package name to be used for the new project"
       )
+
+subpackageName :: Parser String
+subpackageName =
+  O.strOption
+    ( O.long "subpackage"
+        <> O.help "Name of a subpackage to initialize within the current workspace"
+    )
+
+initMode :: Parser Init.InitMode
+initMode =
+  (Init.InitSubpackage <$> subpackageName)
+  <|> (Init.InitWorkspace <$> maybePackageName)
+  <|> Prelude.pure (Init.InitWorkspace Nothing)
 
 ensureRanges :: Parser Boolean
 ensureRanges =

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -9,7 +9,6 @@ import Options.Applicative as O
 import Options.Applicative.Types as OT
 import Spago.Command.Init as Init
 import Spago.Core.Config as Core
-import Spago.Prelude as Prelude
 
 flagMaybe ∷ ∀ (a ∷ Type). a -> Mod FlagFields (Maybe a) -> Parser (Maybe a)
 flagMaybe a mod = O.flag Nothing (Just a) mod
@@ -180,8 +179,8 @@ transitive =
         <> O.help "Include transitive dependencies"
     )
 
-pure :: Parser Boolean
-pure =
+pureLockfile :: Parser Boolean
+pureLockfile =
   O.switch
     ( O.long "pure"
         <> O.help "Use the package information from the current lockfile, even if it is out of date"
@@ -314,7 +313,7 @@ initMode :: Parser Init.InitMode
 initMode =
   (Init.InitSubpackage <$> { packageName: _ } <$> subpackageName)
     <|> (Init.InitWorkspace <$> { packageName: _ } <$> maybePackageName)
-    <|> Prelude.pure (Init.InitWorkspace { packageName: Nothing })
+    <|> pure (Init.InitWorkspace { packageName: Nothing })
 
 ensureRanges :: Parser Boolean
 ensureRanges =

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -312,9 +312,9 @@ subpackageName =
 
 initMode :: Parser Init.InitMode
 initMode =
-  (Init.InitSubpackage <$> subpackageName)
-    <|> (Init.InitWorkspace <$> maybePackageName)
-    <|> Prelude.pure (Init.InitWorkspace Nothing)
+  (Init.InitSubpackage <$> { packageName: _ } <$> subpackageName)
+    <|> (Init.InitWorkspace <$> { packageName: _ } <$> maybePackageName)
+    <|> Prelude.pure (Init.InitWorkspace { packageName: Nothing })
 
 ensureRanges :: Parser Boolean
 ensureRanges =

--- a/bin/src/Flags.purs
+++ b/bin/src/Flags.purs
@@ -313,8 +313,8 @@ subpackageName =
 initMode :: Parser Init.InitMode
 initMode =
   (Init.InitSubpackage <$> subpackageName)
-  <|> (Init.InitWorkspace <$> maybePackageName)
-  <|> Prelude.pure (Init.InitWorkspace Nothing)
+    <|> (Init.InitWorkspace <$> maybePackageName)
+    <|> Prelude.pure (Init.InitWorkspace Nothing)
 
 ensureRanges :: Parser Boolean
 ensureRanges =

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -55,7 +55,6 @@ import Spago.Paths as Paths
 import Spago.Purs as Purs
 import Spago.Registry as Registry
 import Spago.Repl as SpagoRepl
-import Unsafe.Coerce (unsafeCoerce)
 
 type GlobalArgs =
   { noColor :: Boolean
@@ -603,7 +602,7 @@ main = do
                 env <- mkRegistryEnv offline
                 void $ runSpago env $ Init.run
                   { setVersion: Nothing
-                  , mode: Init.InitWorkspace (Just $ unsafeCoerce "repl")
+                  , mode: Init.InitWorkspace { packageName: Just "repl" }
                   , useSolver: true
                   }
                 pure $ List.fromFoldable [ "effect", "console" ] -- TODO newPackages

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -303,7 +303,7 @@ fetchArgsParser =
     , selectedPackage: Flags.selectedPackage
     , ensureRanges: Flags.ensureRanges
     , testDeps: Flags.testDeps
-    , pure: Flags.pure
+    , pure: Flags.pureLockfile
     }
 
 sourcesArgsParser :: Parser SourcesArgs
@@ -324,7 +324,7 @@ installArgsParser =
     , pedanticPackages: Flags.pedanticPackages
     , ensureRanges: Flags.ensureRanges
     , testDeps: Flags.testDeps
-    , pure: Flags.pure
+    , pure: Flags.pureLockfile
     }
 
 uninstallArgsParser :: Parser UninstallArgs
@@ -346,7 +346,7 @@ buildArgsParser = Optparse.fromRecord
   , jsonErrors: Flags.jsonErrors
   , strict: Flags.strict
   , statVerbosity: Flags.statVerbosity
-  , pure: Flags.pure
+  , pure: Flags.pureLockfile
   }
 
 replArgsParser :: Parser ReplArgs
@@ -368,7 +368,7 @@ runArgsParser = Optparse.fromRecord
   , ensureRanges: Flags.ensureRanges
   , strict: Flags.strict
   , statVerbosity: Flags.statVerbosity
-  , pure: Flags.pure
+  , pure: Flags.pureLockfile
   }
 
 upgradeArgsParser :: Parser UpgradeArgs
@@ -387,7 +387,7 @@ testArgsParser = Optparse.fromRecord
   , pedanticPackages: Flags.pedanticPackages
   , strict: Flags.strict
   , statVerbosity: Flags.statVerbosity
-  , pure: Flags.pure
+  , pure: Flags.pureLockfile
   }
 
 bundleArgsParser :: Parser BundleArgs
@@ -409,7 +409,7 @@ bundleArgsParser =
     , ensureRanges: Flags.ensureRanges
     , strict: Flags.strict
     , statVerbosity: Flags.statVerbosity
-    , pure: Flags.pure
+    , pure: Flags.pureLockfile
     }
 
 publishArgsParser :: Parser PublishArgs
@@ -485,7 +485,7 @@ lsPathsArgsParser = Optparse.fromRecord
 lsPackagesArgsParser :: Parser LsPackagesArgs
 lsPackagesArgsParser = Optparse.fromRecord
   { json: Flags.json
-  , pure: Flags.pure
+  , pure: Flags.pureLockfile
   }
 
 lsDepsArgsParser :: Parser LsDepsArgs
@@ -493,7 +493,7 @@ lsDepsArgsParser = Optparse.fromRecord
   { json: Flags.json
   , transitive: Flags.transitive
   , selectedPackage: Flags.selectedPackage
-  , pure: Flags.pure
+  , pure: Flags.pureLockfile
   }
 
 data Cmd a = Cmd'SpagoCmd (SpagoCmd a) | Cmd'VersionCmd Boolean

--- a/bin/src/Main.purs
+++ b/bin/src/Main.purs
@@ -12,11 +12,9 @@ import Data.Foldable as Foldable
 import Data.List as List
 import Data.Maybe as Maybe
 import Data.Set as Set
-import Data.String as String
 import Effect.Aff as Aff
 import Effect.Aff.AVar as AVar
 import Effect.Now as Now
-import Node.Path as Path
 import Node.Process as Process
 import Options.Applicative (CommandFields, Mod, Parser, ParserPrefs(..))
 import Options.Applicative as O
@@ -53,12 +51,11 @@ import Spago.Generated.BuildInfo as BuildInfo
 import Spago.Git as Git
 import Spago.Json as Json
 import Spago.Log (LogVerbosity(..))
-import Spago.Log as Log
 import Spago.Paths as Paths
 import Spago.Purs as Purs
 import Spago.Registry as Registry
 import Spago.Repl as SpagoRepl
-import Unsafe.Coerce as UnsafeCoerce
+import Unsafe.Coerce (unsafeCoerce)
 
 type GlobalArgs =
   { noColor :: Boolean
@@ -70,7 +67,7 @@ type GlobalArgs =
 
 type InitArgs =
   { setVersion :: Maybe String
-  , name :: Maybe String
+  , mode :: Init.InitMode
   , useSolver :: Boolean
   }
 
@@ -296,7 +293,7 @@ initArgsParser :: Parser InitArgs
 initArgsParser =
   Optparse.fromRecord
     { setVersion: Flags.maybeSetVersion
-    , name: Flags.maybePackageName
+    , mode: Flags.initMode
     , useSolver: Flags.useSolver
     }
 
@@ -547,24 +544,10 @@ main = do
               }
             void $ runSpago env (Sources.run { json: args.json })
           Init args@{ useSolver } -> do
-            -- Figure out the package name from the current dir
-            let candidateName = fromMaybe (String.take 150 $ Path.basename Paths.cwd) args.name
-            logDebug [ show Paths.cwd, show candidateName ]
-            packageName <- case PackageName.parse (PackageName.stripPureScriptPrefix candidateName) of
-              Left err -> die
-                [ toDoc "Could not figure out a name for the new package. Error:"
-                , Log.break
-                , Log.indent2 $ toDoc err
-                ]
-              Right p -> pure p
-            setVersion <- parseSetVersion args.setVersion
-            logDebug [ "Got packageName and setVersion:", PackageName.print packageName, unsafeStringify setVersion ]
-            let initOpts = { packageName, setVersion, useSolver }
             -- Fetch the registry here so we can select the right package set later
             env <- mkRegistryEnv offline
-            void $ runSpago env $ Init.run initOpts
-            logInfo "Set up a new Spago project."
-            logInfo "Try running `spago run`"
+            setVersion <- parseSetVersion args.setVersion
+            void $ runSpago env $ Init.run { mode: args.mode, setVersion, useSolver }
           Fetch args -> do
             { env, fetchOpts } <- mkFetchEnv (Record.merge { isRepl: false, migrateConfig, offline } args)
             void $ runSpago env (Fetch.run fetchOpts)
@@ -620,7 +603,7 @@ main = do
                 env <- mkRegistryEnv offline
                 void $ runSpago env $ Init.run
                   { setVersion: Nothing
-                  , packageName: UnsafeCoerce.unsafeCoerce "repl"
+                  , mode: Init.InitWorkspace (Just $ unsafeCoerce "repl")
                   , useSolver: true
                   }
                 pure $ List.fromFoldable [ "effect", "console" ] -- TODO newPackages

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -289,10 +289,10 @@ pursReplFile = { name: ".purs-repl", content: "import Prelude\n" }
 -- ERROR TEXTS -----------------------------------------------------------------
 
 foundExistingProject :: FilePath -> String
-foundExistingProject path = "Found a " <> show path <> " file, skipping copy."
+foundExistingProject path = "Found a \"" <> path <> "\" file, skipping copy."
 
 foundExistingDirectory :: FilePath -> String
-foundExistingDirectory dir = "Found existing directory " <> show dir <> ", skipping copy of sample sources"
+foundExistingDirectory dir = "Found existing directory \"" <> dir <> "\", skipping copy of sample sources"
 
 foundExistingFile :: FilePath -> String
-foundExistingFile file = "Found existing file " <> show file <> ", not overwriting it"
+foundExistingFile file = "Found existing file \"" <> file <> "\", not overwriting it"

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -101,10 +101,11 @@ run opts = do
       false -> FS.writeTextFile dest srcTemplate
 
   getPackageName = do
-    let candidateName = case opts.mode of
-          InitWorkspace Nothing -> String.take 150 $ Path.basename Paths.cwd
-          InitWorkspace (Just n) -> n
-          InitSubpackage n -> n
+    let
+      candidateName = case opts.mode of
+        InitWorkspace Nothing -> String.take 150 $ Path.basename Paths.cwd
+        InitWorkspace (Just n) -> n
+        InitSubpackage n -> n
     logDebug [ show Paths.cwd, show candidateName ]
     pname <- case PackageName.parse (PackageName.stripPureScriptPrefix candidateName) of
       Left err -> die
@@ -135,7 +136,6 @@ run opts = do
       let dirPath = PackageName.print packageName
       unlessM (FS.exists dirPath) $ FS.mkdirp dirPath
       pure dirPath
-
 
 -- TEMPLATES -------------------------------------------------------------------
 

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -284,10 +284,10 @@ pursReplFile = { name: ".purs-repl", content: "import Prelude\n" }
 -- ERROR TEXTS -----------------------------------------------------------------
 
 foundExistingProject :: FilePath -> String
-foundExistingProject path = "Found a " <> show path <> " file, skipping copy."
+foundExistingProject path = "Found a " <> path <> " file, skipping copy."
 
 foundExistingDirectory :: FilePath -> String
-foundExistingDirectory dir = "Found existing directory " <> show dir <> ", skipping copy of sample sources"
+foundExistingDirectory dir = "Found existing directory " <> dir <> ", skipping copy of sample sources"
 
 foundExistingFile :: FilePath -> String
-foundExistingFile file = "Found existing file " <> show file <> ", not overwriting it"
+foundExistingFile file = "Found existing file " <> file <> ", not overwriting it"

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -40,8 +40,6 @@ type InitOptions =
 
 run :: ∀ a. InitOptions -> Spago (RegistryEnv a) Config
 run opts = do
-  logInfo "Initializing a new project..."
-
   -- Use the specified version of the package set (if specified).
   -- Otherwise, get the latest version of the package set for the given compiler
   packageSetVersion <- Registry.findPackageSet opts.setVersion
@@ -51,6 +49,7 @@ run opts = do
   projectDir <- getProjectDir packageName
 
   { purs } <- ask
+  logInfo "Initializing a new project..."
   logInfo $ "Found PureScript " <> Version.print purs.version <> ", will use package set " <> Version.print packageSetVersion
 
   let

--- a/src/Spago/Command/Init.purs
+++ b/src/Spago/Command/Init.purs
@@ -45,12 +45,13 @@ run opts = do
   -- Use the specified version of the package set (if specified).
   -- Otherwise, get the latest version of the package set for the given compiler
   packageSetVersion <- Registry.findPackageSet opts.setVersion
-  { purs } <- ask
-  logInfo $ "Found PureScript " <> Version.print purs.version <> ", will use package set " <> Version.print packageSetVersion
 
   packageName <- getPackageName
   withWorkspace <- getWithWorkspace packageSetVersion
   projectDir <- getProjectDir packageName
+
+  { purs } <- ask
+  logInfo $ "Found PureScript " <> Version.print purs.version <> ", will use package set " <> Version.print packageSetVersion
 
   let
     mainModuleName = "Main"

--- a/test-fixtures/init/subpackage/conflicting-flags.txt
+++ b/test-fixtures/init/subpackage/conflicting-flags.txt
@@ -1,0 +1,28 @@
+Invalid option `--subpackage'
+
+Usage: index.dev.js (COMMAND | (-v|--version))
+  PureScript package manager and build tool
+
+Available options:
+  -h,--help                Show this help text
+  -v,--version             Show the current version
+
+Available commands:
+  init                     Initialise a new project
+  fetch                    Downloads all of the project's dependencies
+  install                  Compile the project's dependencies
+  uninstall                Remove dependencies from a package
+  build                    Compile the project
+  run                      Run the project
+  test                     Test the project
+  bundle                   Bundle the project in a single file
+  sources                  List all the source paths (globs) for the
+                           dependencies of the project
+  repl                     Start a REPL
+  publish                  Publish a package
+  upgrade                  Upgrade to the latest package set, or to the latest
+                           versions of Registry packages
+  docs                     Generate docs for the project and its dependencies
+  registry                 Commands to interact with the Registry
+  ls                       List packages or dependencies
+  graph                    Generate a graph of modules or dependencies

--- a/test-fixtures/init/subpackage/conflicting-flags.txt
+++ b/test-fixtures/init/subpackage/conflicting-flags.txt
@@ -1,28 +1,21 @@
 Invalid option `--subpackage'
 
-Usage: index.dev.js (COMMAND | (-v|--version))
-  PureScript package manager and build tool
+Usage: index.dev.js init [--migrate] [--monochrome|--no-color] [--offline] [-q|--quiet] [-v|--verbose] ([--subpackage ARG] | [--name ARG]) [--package-set ARG] [--use-solver]
+  Initialise a new project
 
 Available options:
+  --migrate                Migrate the spago.yaml file to the latest format
+  --monochrome,--no-color  Force logging without ANSI color escape sequences
+  --offline                Do not attempt to use the network. Warning: this will
+                           fail if you don't have the necessary dependencies
+                           already cached
+  -q,--quiet               Suppress all spago logging
+  -v,--verbose             Enable additional debug logging, e.g. printing `purs`
+                           commands
+  --subpackage ARG         Name of a subpackage to initialize within the current
+                           workspace
+  --name ARG               Optional package name to be used for the new project
+  --package-set ARG        Optional package set version to be used instead of
+                           the latest one
+  --use-solver             Use the solver instead of package sets
   -h,--help                Show this help text
-  -v,--version             Show the current version
-
-Available commands:
-  init                     Initialise a new project
-  fetch                    Downloads all of the project's dependencies
-  install                  Compile the project's dependencies
-  uninstall                Remove dependencies from a package
-  build                    Compile the project
-  run                      Run the project
-  test                     Test the project
-  bundle                   Bundle the project in a single file
-  sources                  List all the source paths (globs) for the
-                           dependencies of the project
-  repl                     Start a REPL
-  publish                  Publish a package
-  upgrade                  Upgrade to the latest package set, or to the latest
-                           versions of Registry packages
-  docs                     Generate docs for the project and its dependencies
-  registry                 Commands to interact with the Registry
-  ls                       List packages or dependencies
-  graph                    Generate a graph of modules or dependencies

--- a/test-fixtures/init/subpackage/existing-src-file.txt
+++ b/test-fixtures/init/subpackage/existing-src-file.txt
@@ -1,5 +1,5 @@
 Initializing a new project...
 Found PureScript 0.15.15, will use package set 58.0.0
-Found existing directory "subdir/src", skipping copy of sample sources
+Found existing directory subdir/src, skipping copy of sample sources
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/existing-src-file.txt
+++ b/test-fixtures/init/subpackage/existing-src-file.txt
@@ -1,5 +1,5 @@
 Initializing a new project...
 Found PureScript a.b.c, will use package set x.y.z
-Found existing directory subdir/src, skipping copy of sample sources
+Found existing directory "subdir/src", skipping copy of sample sources
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/existing-src-file.txt
+++ b/test-fixtures/init/subpackage/existing-src-file.txt
@@ -1,5 +1,5 @@
 Initializing a new project...
-Found PureScript 0.15.15, will use package set 58.0.0
+Found PureScript a.b.c, will use package set x.y.z
 Found existing directory subdir/src, skipping copy of sample sources
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/existing-src-file.txt
+++ b/test-fixtures/init/subpackage/existing-src-file.txt
@@ -1,0 +1,5 @@
+Initializing a new project...
+Found PureScript 0.15.15, will use package set 58.0.0
+Found existing directory "subdir/src", skipping copy of sample sources
+Set up a new Spago project.
+Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
@@ -1,6 +1,6 @@
+‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Initializing a new project...
 Found PureScript a.b.c, will use package set x.y.z
-‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Found a subdir/spago.yaml file, skipping copy.
 Found existing directory subdir/src, skipping copy of sample sources
 Found existing directory subdir/test, skipping copy of sample sources

--- a/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
@@ -1,5 +1,8 @@
 Initializing a new project...
 Found PureScript a.b.c, will use package set x.y.z
 ‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
+Found a subdir/spago.yaml file, skipping copy.
+Found existing directory subdir/src, skipping copy of sample sources
+Found existing directory subdir/test, skipping copy of sample sources
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning-existing-files.txt
@@ -1,8 +1,8 @@
 ‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Initializing a new project...
 Found PureScript a.b.c, will use package set x.y.z
-Found a subdir/spago.yaml file, skipping copy.
-Found existing directory subdir/src, skipping copy of sample sources
-Found existing directory subdir/test, skipping copy of sample sources
+Found a "subdir/spago.yaml" file, skipping copy.
+Found existing directory "subdir/src", skipping copy of sample sources
+Found existing directory "subdir/test", skipping copy of sample sources
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/package-set-solver-warning.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning.txt
@@ -2,4 +2,4 @@ Initializing a new project...
 Found PureScript 0.15.15, will use package set 58.0.0
 ‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Set up a new Spago project.
-Try running `spago run -p subdir2`
+Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/package-set-solver-warning.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning.txt
@@ -1,0 +1,5 @@
+Initializing a new project...
+Found PureScript 0.15.15, will use package set 58.0.0
+‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
+Set up a new Spago project.
+Try running `spago run -p subdir2`

--- a/test-fixtures/init/subpackage/package-set-solver-warning.txt
+++ b/test-fixtures/init/subpackage/package-set-solver-warning.txt
@@ -1,5 +1,5 @@
+‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Initializing a new project...
 Found PureScript a.b.c, will use package set x.y.z
-‼ The --package-set and --use-solver flags are ignored when initializing a subpackage
 Set up a new Spago project.
 Try running `spago run -p subdir`

--- a/test-fixtures/init/subpackage/subdir-spago.yaml
+++ b/test-fixtures/init/subpackage/subdir-spago.yaml
@@ -1,0 +1,9 @@
+package:
+  name: subdir
+  dependencies:
+    - console
+    - effect
+    - prelude
+  test:
+    main: Test.Main
+    dependencies: []

--- a/test-fixtures/init/subpackage/subdir2-spago.yaml
+++ b/test-fixtures/init/subpackage/subdir2-spago.yaml
@@ -1,0 +1,9 @@
+package:
+  name: subdir2
+  dependencies:
+    - console
+    - effect
+    - prelude
+  test:
+    main: Test.Main
+    dependencies: []

--- a/test/Spago/Cli.purs
+++ b/test/Spago/Cli.purs
@@ -32,12 +32,15 @@ spec = Spec.around withTempDir do
       { stdoutFile: stdout
       , stderrFile: stderr
       , result
-      , sanitize:
-          String.trim
-          >>> Regex.replace progNameRegex "Usage: index.dev.js"
-          >>> Regex.replace optionsLineRegex " $1"
+      , sanitize: sanitizeCliHelpOutput
       }
 
+sanitizeCliHelpOutput :: String -> String
+sanitizeCliHelpOutput =
+  String.trim
+  >>> Regex.replace progNameRegex "Usage: index.dev.js"
+  >>> Regex.replace optionsLineRegex " $1"
+  where
   -- On Windows progname has the full path like
   -- "Usage: C:\whatever\index.dev.js", but on Unix
   -- it's just "Usage: index.dev.js"

--- a/test/Spago/Cli.purs
+++ b/test/Spago/Cli.purs
@@ -64,4 +64,4 @@ sanitizeCliHelpOutput =
   --
   --     Usage: index.dev.js build [--option] [--another-option] [--third-option] [--foo] [-f|--force] [--help]
   --
-  optionsLineRegex = unsafeFromRight $ Regex.regex "\\n\\s+(\\(\\[-|\\[-|PACKAGE)" RF.global
+  optionsLineRegex = unsafeFromRight $ Regex.regex "\\n\\s+(\\| \\[-|\\(\\[-|\\[-|PACKAGE)" RF.global

--- a/test/Spago/Init.purs
+++ b/test/Spago/Init.purs
@@ -4,6 +4,7 @@ import Test.Prelude
 
 import Node.Path as Path
 import Spago.FS as FS
+import Test.Spago.InitSubpackage as Subpackage
 import Test.Spec (Spec)
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
@@ -25,3 +26,5 @@ spec = Spec.around withTempDir do
     Spec.it "should use user-specified tag if it exists instead of latest release" \({ spago, fixture } :: TestDirs) -> do
       spago [ "init", "--package-set", "9.0.0", "--name", "7368613235362d47665357393342584955783641314b70674c" ] >>= shouldBeSuccess
       checkFixture "spago.yaml" (fixture "older-package-set-tag.yaml")
+
+    Subpackage.spec

--- a/test/Spago/InitSubpackage.purs
+++ b/test/Spago/InitSubpackage.purs
@@ -3,6 +3,8 @@ module Test.Spago.InitSubpackage where
 import Test.Prelude
 
 import Data.String as String
+import Data.String.Regex as Regex
+import Data.String.Regex.Flags as RF
 import Node.Path as Path
 import Spago.FS as FS
 import Test.Spec (SpecT)
@@ -35,7 +37,7 @@ spec =
       checkFixture "subdir/spago.yaml" (fixture "init/subpackage/subdir-spago.yaml")
 
       spago [ "init", "--use-solver", "--subpackage", "subdir" ]
-        >>= shouldBeSuccessErr' (fixture "init/subpackage/package-set-solver-warning.txt")
+        >>= shouldBeSuccessErr' (fixture "init/subpackage/package-set-solver-warning-existing-files.txt")
       checkFixture "subdir/spago.yaml" (fixture "init/subpackage/subdir-spago.yaml")
 
     Spec.it "does not allow both --name and --subpackage flags" \{ spago, fixture } -> do
@@ -54,5 +56,8 @@ spec =
       , sanitize:
           String.trim
           >>> withForwardSlashes
-          >>> String.replace (String.Pattern "\r\n") (String.Replacement "\n")
+          >>> Regex.replace versionsRegex "Found PureScript a.b.c, will use package set x.y.z"
       }
+
+  versionsRegex = unsafeFromRight $
+    Regex.regex "Found PureScript \\d+\\.\\d+\\.\\d+, will use package set \\d+\\.\\d+\\.\\d+" RF.noFlags

--- a/test/Spago/InitSubpackage.purs
+++ b/test/Spago/InitSubpackage.purs
@@ -1,0 +1,42 @@
+module Test.Spago.InitSubpackage where
+
+import Test.Prelude
+
+import Node.Path as Path
+import Spago.FS as FS
+import Test.Spec (SpecT)
+import Test.Spec as Spec
+
+spec :: SpecT Aff TestDirs Identity Unit
+spec =
+  Spec.describe "subpackage" do
+    Spec.it "sets up a sub-project in a subdirectory" \{ spago, fixture } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      spago [ "init", "--subpackage", "subdir" ] >>= shouldBeSuccess
+      checkFixture "subdir/spago.yaml" (fixture "init/subpackage/subdir-spago.yaml")
+      spago [ "init", "--subpackage", "subdir2" ] >>= shouldBeSuccess
+      checkFixture "subdir2/spago.yaml" (fixture "init/subpackage/subdir2-spago.yaml")
+
+    Spec.it "does not overwrite existing files" \{ spago, fixture } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+      FS.mkdirp "subdir/src"
+      FS.writeTextFile (Path.concat [ "subdir", "src", "Main.purs" ]) "Something"
+      spago [ "init", "--subpackage", "subdir" ]
+        >>= shouldBeSuccessErr (fixture "init/subpackage/existing-src-file.txt")
+      fileContent <- FS.readTextFile (Path.concat [ "subdir", "src", "Main.purs" ])
+      fileContent `shouldEqualStr` "Something"
+
+    Spec.it "warns when --package-set or --use-solver flags are used" \{ spago, fixture } -> do
+      spago [ "init" ] >>= shouldBeSuccess
+
+      spago [ "init", "--package-set", "9.0.0", "--subpackage", "subdir" ]
+        >>= shouldBeSuccessErr (fixture "init/subpackage/package-set-solver-warning.txt")
+      checkFixture "subdir/spago.yaml" (fixture "init/subpackage/subdir-spago.yaml")
+
+      spago [ "init", "--use-solver", "--subpackage", "subdir" ]
+        >>= shouldBeSuccessErr (fixture "init/subpackage/package-set-solver-warning.txt")
+      checkFixture "subdir/spago.yaml" (fixture "init/subpackage/subdir-spago.yaml")
+
+    Spec.it "does not allow both --name and --subpackage flags" \{ spago, fixture } -> do
+      spago [ "init", "--name", "foo", "--subpackage", "bar" ]
+        >>= shouldBeFailureErr (fixture "init/subpackage/conflicting-flags.txt")

--- a/test/Spago/InitSubpackage.purs
+++ b/test/Spago/InitSubpackage.purs
@@ -2,11 +2,11 @@ module Test.Spago.InitSubpackage where
 
 import Test.Prelude
 
-import Data.String as String
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags as RF
 import Node.Path as Path
 import Spago.FS as FS
+import Test.Spago.Cli (sanitizeCliHelpOutput)
 import Test.Spec (SpecT)
 import Test.Spec as Spec
 
@@ -54,7 +54,7 @@ spec =
       , stderrFile: Just fixture
       , result
       , sanitize:
-          String.trim
+          sanitizeCliHelpOutput
           >>> withForwardSlashes
           >>> Regex.replace versionsRegex "Found PureScript a.b.c, will use package set x.y.z"
       }


### PR DESCRIPTION
### Description of the change

Fixes #1137

* `spago init --subpackage foo` creates a new subdirectory `foo` and initializes a project there with workspace-less config.
* `spago init --subpackage foo --name bar` is disallowed.
* When `--subpackage` is used together with `--package-set` and/or `--use-solver`, these options are ignored (obviously) and a warning is printed out.
    * I thought of making them incompatible at `optparse` config level, but decided it would be too unobvious.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)
