### PR TITLE
When publishing, check only the published project's dependencies, not all workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Other improvements:
 - When the `publish.location` field is missing, `spago publish` will attempt to
   figure out the location from Git remotes and write it back to `spago.yaml`.
 - Internally Spago uses stricter-typed file paths.
+- `spago publish` no longer tries to validate all workspace dependencies, but
+  only the (transitive) dependencies of the project being published.
 
 ## [0.21.0] - 2023-05-04
 

--- a/test-fixtures/publish/1307-publish-dependencies/expected-stderr.txt
+++ b/test-fixtures/publish/1307-publish-dependencies/expected-stderr.txt
@@ -1,0 +1,27 @@
+Reading Spago workspace configuration...
+
+✓ Selecting package to build: root
+
+Downloading dependencies...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✓ Build succeeded.
+
+Passed preliminary checks.
+‼ Spago is in offline mode - not pushing the git tag v0.0.1
+Building again with the build plan from the solver...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✓ Build succeeded.
+
+
+✓ Ready for publishing. Calling the registry..
+
+
+✘ Spago is offline - not able to call the Registry.

--- a/test-fixtures/publish/1307-publish-dependencies/spago.yaml
+++ b/test-fixtures/publish/1307-publish-dependencies/spago.yaml
@@ -1,0 +1,14 @@
+package:
+  name: root
+  dependencies:
+    - prelude: ">=6.0.1 <7.0.0"
+    - effect: ">=4.0.0 <5.0.0"
+  publish:
+    version: 0.0.1
+    license: MIT
+    location:
+      githubOwner: purescript
+      githubRepo: aaa
+workspace:
+  packageSet:
+    registry: 62.2.5

--- a/test-fixtures/publish/1307-publish-dependencies/src/Main.purs
+++ b/test-fixtures/publish/1307-publish-dependencies/src/Main.purs
@@ -1,0 +1,7 @@
+module Root where
+
+import Prelude
+import Effect (Effect)
+
+main :: Effect Unit
+main = pure unit

--- a/test-fixtures/publish/1307-publish-dependencies/subdir/spago.yaml
+++ b/test-fixtures/publish/1307-publish-dependencies/subdir/spago.yaml
@@ -1,0 +1,8 @@
+package:
+  name: subdir
+  dependencies:
+    - root
+    - prelude
+  publish:
+    version: 0.0.1
+    license: MIT

--- a/test-fixtures/publish/1307-publish-dependencies/subdir/src/Main.purs
+++ b/test-fixtures/publish/1307-publish-dependencies/subdir/src/Main.purs
@@ -1,0 +1,4 @@
+module Subdir where
+
+anExport :: String
+anExport = "Hello, World!"

--- a/test/Spago/Publish.purs
+++ b/test/Spago/Publish.purs
@@ -78,6 +78,13 @@ spec = Spec.around withTempDir do
       spago [ "fetch" ] >>= shouldBeSuccess
       spago [ "publish", "--offline" ] >>= shouldBeFailureErr (fixture "publish/ready.txt")
 
+    Spec.it "#1307 allows other non-published projects to reference local project in the workspace" \{ spago, fixture, testCwd } -> do
+      FS.copyTree { src: fixture "publish/1307-publish-dependencies", dst: testCwd }
+      spago [ "build" ] >>= shouldBeSuccess
+      doTheGitThing
+      spago [ "fetch" ] >>= shouldBeSuccess
+      spago [ "publish", "-p", "root", "--offline" ] >>= shouldBeFailureErr (fixture "publish/1307-publish-dependencies/expected-stderr.txt")
+
   Spec.describe "transfer" do
 
     Spec.it "fails if the publish config is not specified" \{ spago, fixture } -> do


### PR DESCRIPTION
### Description of the change

Fixes #1307 

`spago publish` no longer refuses to publish the root project when another project in the workspace has it as a dependency.

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] ~Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)