### PR TITLE
Fix typo in bundle section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ See the help message for more flags, and [the configuration format section](#the
 When bundling an `app`, the output will be a single executable file:
 
 ```console
-$ spago bundle --to index.js --bundle-type app --platform node
+$ spago bundle --outfile index.js --bundle-type app --platform node
 
 # It is then possible to run it with node:
 $ node index.js


### PR DESCRIPTION
correct the bundle parameter --to to --outfile

### Description of the change

TODO

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
