### PR TITLE
replace version badges pointing to spago-legacy 0.21 with new Spago version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # spago
 
 ![NPM Version (with dist tag)](https://img.shields.io/npm/v/spago/next)
-[![Latest release](https://img.shields.io/github/v/release/purescript/spago.svg)](https://github.com/purescript/spago/releases)
+![Latest release](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fpurescript%2Fspago%2Frefs%2Fheads%2Fmaster%2Fspago.yaml&query=package.publish.version&prefix=v&label=release)
 [![build](https://github.com/purescript/spago/actions/workflows/build.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/build.yml)
 [![nix-flake](https://github.com/purescript/spago/actions/workflows/nix-flake.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/nix-flake.yml)
 [![Maintainer: f-f](https://img.shields.io/badge/maintainer-f%2d-f-teal.svg)](http://github.com/f-f)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spago
 
-[![npm](https://img.shields.io/npm/v/spago.svg)][spago-npm]
+![NPM Version (with dist tag)](https://img.shields.io/npm/v/spago/next)
 [![Latest release](https://img.shields.io/github/v/release/purescript/spago.svg)](https://github.com/purescript/spago/releases)
 [![build](https://github.com/purescript/spago/actions/workflows/build.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/build.yml)
 [![nix-flake](https://github.com/purescript/spago/actions/workflows/nix-flake.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/nix-flake.yml)


### PR DESCRIPTION
### Description of the change
There are two badges in the readme which are misleading.
The first points to `spago@latest` on NPM. The second points to the latest GitHub Packages in this repository, which has not been updated from `spago-legacy`.

This PR updates both badges.

The NPM badge is configured to point to `spago@next` on NPM, via: https://shields.io/badges/npm-version-with-dist-tag
Preview:
![NPM Version (with dist tag)](https://img.shields.io/npm/v/spago/next)

The badge which replaces the GitHub Packages release version is configured via: https://shields.io/badges/dynamic-yaml-badge
It works by extracting the version from
https://raw.githubusercontent.com/purescript/spago/refs/heads/master/spago.yaml at path `package.publish.version`
Preview:
![Latest release](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fpurescript%2Fspago%2Frefs%2Fheads%2Fmaster%2Fspago.yaml&query=package.publish.version&prefix=v&label=release)



### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
