### PR TITLE
replace NPM badge pointing to `spago@latest` with `spago@next`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spago
 
-[![npm](https://img.shields.io/npm/v/spago.svg)][spago-npm]
+![NPM Version (with dist tag)](https://img.shields.io/npm/v/spago/next)
 [![Latest release](https://img.shields.io/github/v/release/purescript/spago.svg)](https://github.com/purescript/spago/releases)
 [![build](https://github.com/purescript/spago/actions/workflows/build.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/build.yml)
 [![nix-flake](https://github.com/purescript/spago/actions/workflows/nix-flake.yml/badge.svg)](https://github.com/purescript/spago/actions/workflows/nix-flake.yml)


### PR DESCRIPTION
### Description of the change

Uses:
https://shields.io/badges/npm-version-with-dist-tag


Preview:
![NPM Version (with dist tag)](https://img.shields.io/npm/v/spago/next)

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
