### PR TITLE
When resolving modules in graph, glob their paths relative to their own roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ Other improvements:
   their specified dependency ranges.
 - `spago publish` no longer tries to validate all workspace dependencies, but
   only the (transitive) dependencies of the project being published.
-- Restored broken search-directed search in generated docs.
+- Restored broken type-directed search in generated docs.
+- `spago graph modules` now correctly reports extra-packages located outside the
+  workspace root.
 
 ## [0.21.0] - 2023-05-04
 

--- a/src/Spago/Config.purs
+++ b/src/Spago/Config.purs
@@ -653,10 +653,8 @@ data WithTestGlobs
   | OnlyTestGlobs
 
 sourceGlob :: RootPath -> WithTestGlobs -> PackageName -> Package -> Array LocalPath
-sourceGlob root withTestGlobs name package =
-  localGlobs <#> (packageRoot </> _)
-  where
-  localGlobs = case package of
+sourceGlob root withTestGlobs name package = map (\p -> getLocalPackageLocation root name package </> p)
+  case package of
     WorkspacePackage { hasTests } ->
       case hasTests, withTestGlobs of
         false, OnlyTestGlobs -> []
@@ -666,8 +664,6 @@ sourceGlob root withTestGlobs name package =
         true, WithTestGlobs -> [ srcGlob, testGlob ]
     GitPackage { subdir: Just s } -> [ Node.Path.concat [ s, srcGlob ] ]
     _ -> [ srcGlob ]
-
-  packageRoot = getLocalPackageLocation root name package
 
 srcGlob :: String
 srcGlob = "src/**/*.purs"

--- a/src/Spago/Config.purs
+++ b/src/Spago/Config.purs
@@ -653,8 +653,10 @@ data WithTestGlobs
   | OnlyTestGlobs
 
 sourceGlob :: RootPath -> WithTestGlobs -> PackageName -> Package -> Array LocalPath
-sourceGlob root withTestGlobs name package = map (\p -> getLocalPackageLocation root name package </> p)
-  case package of
+sourceGlob root withTestGlobs name package =
+  localGlobs <#> (packageRoot </> _)
+  where
+  localGlobs = case package of
     WorkspacePackage { hasTests } ->
       case hasTests, withTestGlobs of
         false, OnlyTestGlobs -> []
@@ -664,6 +666,8 @@ sourceGlob root withTestGlobs name package = map (\p -> getLocalPackageLocation 
         true, WithTestGlobs -> [ srcGlob, testGlob ]
     GitPackage { subdir: Just s } -> [ Node.Path.concat [ s, srcGlob ] ]
     _ -> [ srcGlob ]
+
+  packageRoot = getLocalPackageLocation root name package
 
 srcGlob :: String
 srcGlob = "src/**/*.purs"

--- a/src/Spago/Purs/Graph.purs
+++ b/src/Spago/Purs/Graph.purs
@@ -131,8 +131,8 @@ getModuleGraphWithPackage (ModuleGraph graph) = do
   pure packageGraph
 
 compileGlob :: ∀ a. RootPath -> LocalPath -> Spago { rootPath :: RootPath | a } (Array LocalPath)
-compileGlob rootPath sourcePath = do
-  liftAff $ Glob.gitignoringGlob
+compileGlob rootPath sourcePath = liftAff $
+  Glob.gitignoringGlob
     { root: rootPath
     , includePatterns: [ Path.localPart $ withForwardSlashes sourcePath ]
     , ignorePatterns: []

--- a/src/Spago/Purs/Graph.purs
+++ b/src/Spago/Purs/Graph.purs
@@ -124,7 +124,7 @@ getModuleGraphWithPackage (ModuleGraph graph) = do
         newVal = do
           package <- Map.lookup newPath pathToPackage
           pure { path: Path.localPart newPath, depends, package }
-      in --trace { moduleName, newPath, newVal } \_ ->
+      in
         maybe pkgGraph (\v -> Map.insert moduleName v pkgGraph) newVal
     packageGraph = foldl addPackageInfo Map.empty (Map.toUnfoldable graph :: Array _)
 

--- a/test-fixtures/1281-local-fs-extra-packages/consumer/spago.yaml
+++ b/test-fixtures/1281-local-fs-extra-packages/consumer/spago.yaml
@@ -1,0 +1,11 @@
+package:
+  name: consumer
+  dependencies:
+    - extra-package
+
+workspace:
+  packageSet:
+    registry: 41.5.0
+  extraPackages:
+    extra-package:
+      path: ../extra-package

--- a/test-fixtures/1281-local-fs-extra-packages/consumer/src/Main.purs
+++ b/test-fixtures/1281-local-fs-extra-packages/consumer/src/Main.purs
@@ -1,0 +1,6 @@
+module Consumer where
+
+import ExtraPackage (x)
+
+y :: Int
+y = x

--- a/test-fixtures/1281-local-fs-extra-packages/expected-stdout.txt
+++ b/test-fixtures/1281-local-fs-extra-packages/expected-stdout.txt
@@ -1,0 +1,9 @@
+Consumer:
+  depends:
+    - ExtraPackage
+  package: consumer
+  path: src/Main.purs
+ExtraPackage:
+  depends: []
+  package: extra-package
+  path: ../extra-package/src/Main.purs

--- a/test-fixtures/1281-local-fs-extra-packages/extra-package/spago.yaml
+++ b/test-fixtures/1281-local-fs-extra-packages/extra-package/spago.yaml
@@ -1,0 +1,7 @@
+package:
+  name: extra-package
+  dependencies: []
+
+workspace:
+  packageSet:
+    registry: 41.5.0

--- a/test-fixtures/1281-local-fs-extra-packages/extra-package/src/Main.purs
+++ b/test-fixtures/1281-local-fs-extra-packages/extra-package/src/Main.purs
@@ -1,0 +1,4 @@
+module ExtraPackage where
+
+x :: Int
+x = 42

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/expected-stderr-unused.txt
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/expected-stderr-unused.txt
@@ -1,0 +1,21 @@
+Reading Spago workspace configuration...
+
+✓ Selecting package to build: packagec
+
+Downloading dependencies...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✓ Build succeeded.
+
+Looking for unused and undeclared transitive dependencies...
+
+✘ Found unused and/or undeclared transitive dependencies:
+
+Sources for package 'packagec' declare unused dependencies - please remove them from the project config:
+  - packageb
+
+These errors can be fixed by running the below command(s):
+spago uninstall -p packagec packageb

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/expected-stderr-used.txt
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/expected-stderr-used.txt
@@ -1,0 +1,13 @@
+Reading Spago workspace configuration...
+
+✓ Selecting package to build: packagea
+
+Downloading dependencies...
+Building...
+           Src   Lib   All
+Warnings     0     0     0
+Errors       0     0     0
+
+✓ Build succeeded.
+
+Looking for unused and undeclared transitive dependencies...

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packagea/spago.yaml
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packagea/spago.yaml
@@ -1,0 +1,11 @@
+package:
+  name: packagea
+  dependencies:
+    - maybe
+    - packageb
+workspace:
+  packageSet:
+    registry: 58.0.1
+  extraPackages:
+    packageb:
+      path: ../packageb

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packagea/src/PackageA.purs
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packagea/src/PackageA.purs
@@ -1,0 +1,14 @@
+module PackageA
+  ( sample
+  )
+where
+
+import Data.Maybe (Maybe(..))
+import PackageB (exampleFunc)
+
+sample :: forall a. Maybe a
+sample =
+  case exampleFunc of
+    Just val -> Just val
+    Nothing -> Nothing
+

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packageb/spago.yaml
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packageb/spago.yaml
@@ -1,0 +1,9 @@
+package:
+  name: packageb
+  dependencies:
+    - maybe
+  build:
+    strict: true
+workspace:
+  packageSet:
+    registry: 58.0.1

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packageb/src/PackageB.purs
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packageb/src/PackageB.purs
@@ -1,0 +1,9 @@
+module PackageB
+  ( exampleFunc
+  )
+where
+
+import Data.Maybe (Maybe(..))
+
+exampleFunc :: forall a. Maybe a
+exampleFunc = Nothing

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packagec/spago.yaml
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packagec/spago.yaml
@@ -1,0 +1,11 @@
+package:
+  name: packagec
+  dependencies:
+    - maybe
+    - packageb
+workspace:
+  packageSet:
+    registry: 58.0.1
+  extraPackages:
+    packageb:
+      path: ../packageb

--- a/test-fixtures/pedantic/1281-local-fs-extra-packages/packagec/src/PackageC.purs
+++ b/test-fixtures/pedantic/1281-local-fs-extra-packages/packagec/src/PackageC.purs
@@ -1,0 +1,9 @@
+module PackageC
+  ( sample
+  )
+where
+
+import Data.Maybe (Maybe(..))
+
+sample :: forall a. Maybe a
+sample = Nothing

--- a/test-fixtures/pedantic/check-pedantic-packages.txt
+++ b/test-fixtures/pedantic/check-pedantic-packages.txt
@@ -14,7 +14,7 @@ Looking for unused and undeclared transitive dependencies...
 
 ✘ Found unused and/or undeclared transitive dependencies:
 
-Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Sources for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - console
   - effect
   - either
@@ -24,7 +24,7 @@ Sources for package 'pedantic' import the following transitive dependencies - pl
     from `Main`, which imports:
       Data.Newtype
 
-Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Tests for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - tuples
 
 Tests for package 'pedantic' import the following transitive dependencies - please add them to the project dependencies, or remove the imports:

--- a/test-fixtures/pedantic/check-unused-dependency-in-source.txt
+++ b/test-fixtures/pedantic/check-unused-dependency-in-source.txt
@@ -14,7 +14,7 @@ Looking for unused and undeclared transitive dependencies...
 
 ✘ Found unused and/or undeclared transitive dependencies:
 
-Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Sources for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - console
   - effect
 

--- a/test-fixtures/pedantic/check-unused-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-dependency.txt
@@ -14,7 +14,7 @@ Looking for unused and undeclared transitive dependencies...
 
 ✘ Found unused and/or undeclared transitive dependencies:
 
-Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Sources for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - console
   - effect
 

--- a/test-fixtures/pedantic/check-unused-source-and-test-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-source-and-test-dependency.txt
@@ -14,11 +14,11 @@ Looking for unused and undeclared transitive dependencies...
 
 ✘ Found unused and/or undeclared transitive dependencies:
 
-Sources for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Sources for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - console
   - effect
 
-Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Tests for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - console
   - effect
 

--- a/test-fixtures/pedantic/check-unused-test-dependency.txt
+++ b/test-fixtures/pedantic/check-unused-test-dependency.txt
@@ -14,7 +14,7 @@ Looking for unused and undeclared transitive dependencies...
 
 ✘ Found unused and/or undeclared transitive dependencies:
 
-Tests for package 'pedantic' declares unused dependencies - please remove them from the project config:
+Tests for package 'pedantic' declare unused dependencies - please remove them from the project config:
   - newtype
 
 These errors can be fixed by running the below command(s):

--- a/test/Spago/Build/Monorepo.purs
+++ b/test/Spago/Build/Monorepo.purs
@@ -192,7 +192,7 @@ spec = Spec.describe "monorepo" do
 
       mkUnusedDepErr isSrc package =
         Array.intercalate "\n"
-          [ toMsgPrefix isSrc <> " for package '" <> package <> "' declares unused dependencies - please remove them from the project config:"
+          [ toMsgPrefix isSrc <> " for package '" <> package <> "' declare unused dependencies - please remove them from the project config:"
           , "  - " <> (if isSrc then "tuples" else "either")
           ]
       mkTransitiveDepErr isSrc package = do

--- a/test/Spago/Build/Pedantic.purs
+++ b/test/Spago/Build/Pedantic.purs
@@ -6,7 +6,7 @@ import Data.Array as Array
 import Data.Map as Map
 import Spago.Core.Config (Dependencies(..), Config)
 import Spago.FS as FS
-import Spago.Path as Path
+import Spago.Paths as Paths
 import Test.Spec (SpecT)
 import Test.Spec as Spec
 
@@ -206,13 +206,26 @@ spec =
       Spec.it
         (".gitignore does not affect discovery of transitive deps (" <> gitignore <> ")") \{ spago, fixture, testCwd } -> do
           FS.copyTree { src: fixture "pedantic/follow-instructions", dst: testCwd }
-          FS.writeTextFile (Path.global ".gitignore") gitignore
+          FS.writeTextFile (testCwd </> ".gitignore") gitignore
           spago [ "uninstall", "effect" ] >>= shouldBeSuccess
           -- Get rid of "Compiling..." messages
           spago [ "build" ] >>= shouldBeSuccess
           editSpagoYaml (addPedanticFlagToSrc)
           spago [ "build" ] >>= shouldBeFailureErr (fixture "pedantic/pedantic-instructions-initial-failure.txt")
           spago [ "install", "-p", "follow-instructions", "effect" ] >>= shouldBeSuccessErr (fixture "pedantic/pedantic-instructions-installation-result.txt")
+
+    Spec.it "#1281 treats extra-packages on the local file system as used" \{ spago, fixture, testCwd } -> do
+      FS.copyTree { src: fixture "pedantic/1281-local-fs-extra-packages", dst: testCwd }
+
+      Paths.chdir $ testCwd </> "packagea"
+      spago [ "build" ] >>= shouldBeSuccess
+      spago [ "build", "--pedantic-packages" ]
+        >>= shouldBeSuccessErr (fixture "pedantic/1281-local-fs-extra-packages/expected-stderr-used.txt")
+
+      Paths.chdir $ testCwd </> "packagec"
+      spago [ "build" ] >>= shouldBeSuccess
+      spago [ "build", "--pedantic-packages" ]
+        >>= shouldBeFailureErr (fixture "pedantic/1281-local-fs-extra-packages/expected-stderr-unused.txt")
 
 addPedanticFlagToSrc :: Config -> Config
 addPedanticFlagToSrc config = config

--- a/test/Spago/Graph.purs
+++ b/test/Spago/Graph.purs
@@ -2,6 +2,8 @@ module Test.Spago.Graph where
 
 import Test.Prelude
 
+import Spago.FS as FS
+import Spago.Paths as Paths
 import Test.Spec (Spec)
 import Test.Spec as Spec
 
@@ -32,3 +34,8 @@ spec = Spec.around withTempDir do
     Spec.it "can topologically sort packages" \{ spago, fixture } -> do
       spago [ "init", "--name", "my-project", "--package-set", "41.2.0" ] >>= shouldBeSuccess
       spago [ "graph", "packages", "--topo" ] >>= shouldBeSuccessOutput (fixture "graph-packages-topo.txt")
+
+    Spec.it "#1281 correctly reports modules from extra-packages on the local file system" \{ spago, fixture, testCwd } -> do
+      FS.copyTree { src: fixture "1281-local-fs-extra-packages", dst: testCwd }
+      Paths.chdir $ testCwd </> "consumer"
+      spago [ "graph", "modules" ] >>= shouldBeSuccessOutput (fixture "1281-local-fs-extra-packages/expected-stdout.txt")


### PR DESCRIPTION
### Description of the change

Fixes #1281

The root of the issue is in how `purs graph` is annotated with package names. For every package we try to glob all its source `*.purs` files using `gitignoringGlob`, which takes a `root` parameter (formerly `cwd`). Why does it take that parameter, pray tell? Turns out that's the directory under which the globbing is to take place. The function will never go outside that directory.

And this in turn means that, if we give it the root of the workspace as the `root` parameter, it will never find any files outside the workspace! Such as, for example, `../another-package/src/File.purs` or something like that.

Initially I considered switching to [the `glob` package](https://www.npmjs.com/package/glob), which can surprisingly glob outside the root fine, but it doesn't support `.gitignore` files. Then I looked at [the `globby` package](https://www.npmjs.com/package/globby), which does support `.gitignore` files, but alas, doesn't support going outside the root.

And then it suddenly occurred to me 🤦 that I don't actually need to go outside the root. I just need to use a different root! Every given package's files are all guaranteed to live under that same package's own root, be it within the current workspace or without it. So that's what I did: every package's files are now globbed relative to its own root, and then the results are made relative to the workspace root again. Works like a charm!

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- ~[ ] Added some example of the new feature to the `README`~
- [x] Added a test for the contribution (if applicable)
    - I added tests for both `spago graph` (since that was where the problem actually occurred) and `spago build --pedantic-packages` (because that's where the problem was originally reported).