### PR TITLE
Regex fix missing git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Other improvements:
 - Restored broken type-directed search in generated docs.
 - `spago graph modules` now correctly reports extra-packages located outside the
   workspace root.
+- on `spago publish` - add support for urls without `.git` suffix.
+  Before: `ssh://git@github.com/foo/bar.git` - ok, `ssh://git@github.com/foo/bar` - error
+  After: `ssh://git@github.com/foo/bar.git` - ok, `ssh://git@github.com/foo/bar` - ok
 
 ## [0.21.0] - 2023-05-04
 

--- a/src/Spago/Git.purs
+++ b/src/Spago/Git.purs
@@ -22,11 +22,10 @@ import Control.Monad.Except (ExceptT(..))
 import Control.Monad.Except as Except
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
-import Data.Maybe (fromJust)
 import Data.String (Pattern(..))
 import Data.String as String
-import Data.String.Regex as Regex
-import Partial.Unsafe (unsafePartial)
+import Data.String.Regex (match, split) as Regex
+import Data.String.Regex.Unsafe (unsafeRegex) as Regex
 import Registry.Version as Version
 import Spago.Cmd as Cmd
 import Spago.FS as FS
@@ -197,7 +196,5 @@ parseRemote = \line ->
     _ ->
       Nothing
   where
-  tabOrSpaceRegex = unsafePartial $ fromJust $ hush $
-    Regex.regex "\\s+" mempty
-  gitUrlRegex = unsafePartial $ fromJust $ hush $
-    Regex.regex "^((ssh:\\/\\/)?[^@]+@[^:]+[:\\/]|https?:\\/\\/[^\\/]+\\/)(.*)\\/(.+)\\.git$" mempty
+  tabOrSpaceRegex = Regex.unsafeRegex "\\s+" mempty
+  gitUrlRegex = Regex.unsafeRegex "^((ssh:\\/\\/)?[^@]+@[^:]+[:\\/]|https?:\\/\\/[^\\/]+\\/)(.*)\\/(.+)\\.git$" mempty

--- a/src/Spago/Git.purs
+++ b/src/Spago/Git.purs
@@ -197,4 +197,4 @@ parseRemote = \line ->
       Nothing
   where
   tabOrSpaceRegex = Regex.unsafeRegex """\s+""" mempty
-  gitUrlRegex = Regex.unsafeRegex """^((ssh:\/\/)?[^@]+@[^:]+[:\/]|https?:\/\/[^\/]+\/)(.*)\/(.+)\.git$""" mempty
+  gitUrlRegex = Regex.unsafeRegex """^((ssh:\/\/)?[^@]+@[^:]+[:\/]|https?:\/\/[^\/]+\/)([^\/]+)\/([^\/]+?)(?:\.git)?$""" mempty

--- a/src/Spago/Git.purs
+++ b/src/Spago/Git.purs
@@ -196,5 +196,5 @@ parseRemote = \line ->
     _ ->
       Nothing
   where
-  tabOrSpaceRegex = Regex.unsafeRegex "\\s+" mempty
-  gitUrlRegex = Regex.unsafeRegex "^((ssh:\\/\\/)?[^@]+@[^:]+[:\\/]|https?:\\/\\/[^\\/]+\\/)(.*)\\/(.+)\\.git$" mempty
+  tabOrSpaceRegex = Regex.unsafeRegex """\s+""" mempty
+  gitUrlRegex = Regex.unsafeRegex """^((ssh:\/\/)?[^@]+@[^:]+[:\/]|https?:\/\/[^\/]+\/)(.*)\/(.+)\.git$""" mempty

--- a/test/Spago/Unit/Git.purs
+++ b/test/Spago/Unit/Git.purs
@@ -11,34 +11,38 @@ spec :: Spec Unit
 spec = do
   Spec.describe "Git" do
     Spec.describe "parseRemote" do
+      Spec.describe "successfully parses" do
+        let
+          mkTest input expectedUrl = Spec.it input $ parseRemote input `shouldEqual` Just { name: "origin", url: expectedUrl, owner: "foo", repo: "bar" }
 
-      Spec.it "parses a remote with a git protocol" do
-        parseRemote "origin\tgit@github.com:foo/bar.git (fetch)"
-          `shouldEqual` Just { name: "origin", url: "git@github.com:foo/bar.git", owner: "foo", repo: "bar" }
-        parseRemote "origin  git@github.com:foo/bar.git (fetch)"
-          `shouldEqual` Just { name: "origin", url: "git@github.com:foo/bar.git", owner: "foo", repo: "bar" }
+        Spec.describe "remote with a git protocol" do
+          mkTest "origin\tgit@github.com:foo/bar.git (fetch)" "git@github.com:foo/bar.git"
+          mkTest "origin  git@github.com:foo/bar.git (fetch)" "git@github.com:foo/bar.git"
 
-      Spec.it "parses a remote with an https protocol" do
-        parseRemote "origin\thttps://github.com/foo/bar.git (push)"
-          `shouldEqual` Just { name: "origin", url: "https://github.com/foo/bar.git", owner: "foo", repo: "bar" }
-        parseRemote "origin  https://github.com/foo/bar.git (push)"
-          `shouldEqual` Just { name: "origin", url: "https://github.com/foo/bar.git", owner: "foo", repo: "bar" }
+        Spec.describe "remote with an https protocol" do
+          mkTest "origin\thttps://github.com/foo/bar.git (push)" "https://github.com/foo/bar.git"
+          mkTest "origin  https://github.com/foo/bar.git (push)" "https://github.com/foo/bar.git"
 
-      Spec.it "parses a remote with an ssh protocol" do
-        parseRemote "origin\tssh://git@github.com/foo/bar.git (push)"
-          `shouldEqual` Just { name: "origin", url: "ssh://git@github.com/foo/bar.git", owner: "foo", repo: "bar" }
-        parseRemote "origin  ssh://git@github.com/foo/bar.git (push)"
-          `shouldEqual` Just { name: "origin", url: "ssh://git@github.com/foo/bar.git", owner: "foo", repo: "bar" }
+        Spec.describe "remote with an ssh protocol" do
+          mkTest "origin\tssh://git@github.com/foo/bar.git (push)" "ssh://git@github.com/foo/bar.git"
+          mkTest "origin  ssh://git@github.com/foo/bar.git (push)" "ssh://git@github.com/foo/bar.git"
 
-      Spec.it "rejects malformed remotes" do
-        parseRemote "origin\tgit@github.com:foo/bar.git" `shouldEqual` Nothing
-        parseRemote "origin  git@github.com:foo/bar.git" `shouldEqual` Nothing
+      Spec.describe "rejects" do
+        let mkTest input = Spec.it input $ parseRemote input `shouldEqual` Nothing
 
-        parseRemote "origin\tgit@github.com:foo/bar (push)" `shouldEqual` Nothing
-        parseRemote "origin  git@github.com:foo/bar (push)" `shouldEqual` Nothing
+        Spec.describe "rejects malformed remotes" do
+          Spec.describe "missing trailing (push) or (fetch) field" do
+            mkTest "origin\tgit@github.com:foo/bar.git"
+            mkTest "origin  git@github.com:foo/bar.git"
 
-        parseRemote "origin\tgit@github.com:foo.git (push)" `shouldEqual` Nothing
-        parseRemote "origin  git@github.com:foo.git (push)" `shouldEqual` Nothing
+          Spec.describe "missing .git at the end of repo URL" do
+            mkTest "origin\tgit@github.com:foo/bar (push)"
+            mkTest "origin  git@github.com:foo/bar (push)"
 
-        parseRemote "origin\thttps://foo.com/bar.git (push)" `shouldEqual` Nothing
-        parseRemote "origin  https://foo.com/bar.git (push)" `shouldEqual` Nothing
+          Spec.describe "missing repo name (only owner.git given)" do
+            mkTest "origin\tgit@github.com:foo.git (push)"
+            mkTest "origin  git@github.com:foo.git (push)"
+
+          Spec.describe "non-GitHub domain (unsupported host)" do
+            mkTest "origin\thttps://foo.com/bar.git (push)"
+            mkTest "origin  https://foo.com/bar.git (push)"

--- a/test/Spago/Unit/Git.purs
+++ b/test/Spago/Unit/Git.purs
@@ -18,31 +18,58 @@ spec = do
         Spec.describe "remote with a git protocol" do
           mkTest "origin\tgit@github.com:foo/bar.git (fetch)" "git@github.com:foo/bar.git"
           mkTest "origin  git@github.com:foo/bar.git (fetch)" "git@github.com:foo/bar.git"
+          -- spago should be tolerant to missing .git
+          mkTest "origin\tgit@github.com:foo/bar (fetch)" "git@github.com:foo/bar"
+          mkTest "origin  git@github.com:foo/bar (fetch)" "git@github.com:foo/bar"
 
         Spec.describe "remote with an https protocol" do
           mkTest "origin\thttps://github.com/foo/bar.git (push)" "https://github.com/foo/bar.git"
           mkTest "origin  https://github.com/foo/bar.git (push)" "https://github.com/foo/bar.git"
+          -- spago should be tolerant to missing .git
+          mkTest "origin\thttps://github.com/foo/bar (push)" "https://github.com/foo/bar"
+          mkTest "origin  https://github.com/foo/bar (push)" "https://github.com/foo/bar"
+
+        Spec.describe "remote with an https protocol" do
+          mkTest "origin\thttp://github.com/foo/bar.git (push)" "http://github.com/foo/bar.git"
+          mkTest "origin  http://github.com/foo/bar.git (push)" "http://github.com/foo/bar.git"
+          -- spago should be tolerant to missing .git
+          mkTest "origin\thttp://github.com/foo/bar (push)" "http://github.com/foo/bar"
+          mkTest "origin  http://github.com/foo/bar (push)" "http://github.com/foo/bar"
 
         Spec.describe "remote with an ssh protocol" do
           mkTest "origin\tssh://git@github.com/foo/bar.git (push)" "ssh://git@github.com/foo/bar.git"
           mkTest "origin  ssh://git@github.com/foo/bar.git (push)" "ssh://git@github.com/foo/bar.git"
+          -- spago should be tolerant to missing .git
+          mkTest "origin\tssh://git@github.com/foo/bar (push)" "ssh://git@github.com/foo/bar"
+          mkTest "origin  ssh://git@github.com/foo/bar (push)" "ssh://git@github.com/foo/bar"
 
       Spec.describe "rejects" do
         let mkTest input = Spec.it input $ parseRemote input `shouldEqual` Nothing
 
         Spec.describe "rejects malformed remotes" do
           Spec.describe "missing trailing (push) or (fetch) field" do
+            -- yes, not possible even if edit .git/config
             mkTest "origin\tgit@github.com:foo/bar.git"
             mkTest "origin  git@github.com:foo/bar.git"
 
-          Spec.describe "missing .git at the end of repo URL" do
-            mkTest "origin\tgit@github.com:foo/bar (push)"
-            mkTest "origin  git@github.com:foo/bar (push)"
-
-          Spec.describe "missing repo name (only owner.git given)" do
+          Spec.describe "missing repo name (with or without .git given)" do
+            -- git
             mkTest "origin\tgit@github.com:foo.git (push)"
             mkTest "origin  git@github.com:foo.git (push)"
-
-          Spec.describe "non-GitHub domain (unsupported host)" do
-            mkTest "origin\thttps://foo.com/bar.git (push)"
-            mkTest "origin  https://foo.com/bar.git (push)"
+            mkTest "origin\tgit@github.com:foo (push)"
+            mkTest "origin  git@github.com:foo (push)"
+            -- https
+            mkTest "origin\thttps://github.com:foo.git (push)"
+            mkTest "origin  https://github.com:foo.git (push)"
+            mkTest "origin\thttps://github.com:foo (push)"
+            mkTest "origin  https://github.com:foo (push)"
+            -- http
+            mkTest "origin\thttp://github.com:foo.git (push)"
+            mkTest "origin  http://github.com:foo.git (push)"
+            mkTest "origin\thttp://github.com:foo (push)"
+            mkTest "origin  http://github.com:foo (push)"
+            -- ssh
+            mkTest "origin\tssh://github.com:foo.git (push)"
+            mkTest "origin  ssh://github.com:foo.git (push)"
+            mkTest "origin\tssh://github.com:foo (push)"
+            mkTest "origin  ssh://github.com:foo (push)"


### PR DESCRIPTION
### Description of the change

before

```sh
 ~/projects/purescript-record-extra-srghma   main  git remote -v
origin  ssh://git@github.com/srghma/purescript-record-extra-srghma (fetch)
origin  ssh://git@github.com/srghma/purescript-record-extra-srghma (push)
 ✘  ~/projects/purescript-record-extra-srghma   main  spago publish
Reading Spago workspace configuration...

✓ Selecting package to build: record-extra-srghma

Downloading dependencies...
Building...
           Src   Lib   All
Warnings     0     0     0
Errors       0     0     0

✓ Build succeeded.


✘ Couldn't parse Git remotes:
Could not parse any remotes from the output of `git remote --verbose`.
```

after

```sh
 ~/projects/purescript-record-extra-srghma   main  /home/srghma/projects/spago/bin/index.dev.js publish

... ok

```

### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [x] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
