### PR TITLE
monorepo multiple main modules documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,30 +831,8 @@ The `--package` flag is also available for many more commands, such as `build`, 
 
 An important property of this "monorepo setup" is that the `output` folder will be shared between all the packages: they will share the same build package set (or build plan when using the solver) and they will be all build together.
 
-#### Multiple Main Modules
-
-Given
-```
-.
-├── app1
-│   ├── spago.yaml
-│   └── src
-│       └── Main.purs
-├── app2
-│   ├── spago.yaml
-│   └── src
-│       └── Main.purs
-└── spago.yaml
-```
-
-, to avoid the error `Module Main has been defined multiple times`:
-* `app1` `Main.purs` can have `module Main1`
-* `app2` `Main.purs` can have `module Main2`
-
-From the root, run:
-* `spago run -p app1 --main Main1` 
-or 
-* `spago run -p app2 --main Main2`
+> [!NOTE]\
+> Remember that you can't have multiple modules with the same name in a single project. This usually happens with the `Main` module being defined multiple times. Rename these modules to something unique.
 
 ### Polyrepo support
 

--- a/README.md
+++ b/README.md
@@ -831,6 +831,31 @@ The `--package` flag is also available for many more commands, such as `build`, 
 
 An important property of this "monorepo setup" is that the `output` folder will be shared between all the packages: they will share the same build package set (or build plan when using the solver) and they will be all build together.
 
+#### Multiple Main Modules
+
+Given
+```
+.
+├── app1
+│   ├── spago.yaml
+│   └── src
+│       └── Main.purs
+├── app2
+│   ├── spago.yaml
+│   └── src
+│       └── Main.purs
+└── spago.yaml
+```
+
+, to avoid the error `Module Main has been defined multiple times`:
+* `app1` `Main.purs` can have `module Main1`
+* `app2` `Main.purs` can have `module Main2`
+
+From the root, run:
+* `spago run -p app1 --main Main1` 
+or 
+* `spago run -p app2 --main Main2`
+
 ### Polyrepo support
 
 There might be cases where you want to have multiple loosely-connected codebases in the same repository that do _not_ necessarily build together all the time. This is sometimes called [a "polyrepo"][monorepo-tools].


### PR DESCRIPTION
### Description of the change

This documents a particular use case of the monorepo style:
multiple executable sub-projects in the monorepo. They cannot all have `module Main`.

This solution is equivalent to
```
ghc-options: -main-is Foo
```
in Haskell
https://stackoverflow.com/a/70857560/1007926

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
