### PR TITLE
Fix byPrefix examples in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,7 +1391,9 @@ workspace:
       # Note: when using `byPrefix`, use the `>` for block-string:
       # see https://yaml-multiline.info/
       - byPrefix: >
-        "Data.Map"'s `Semigroup instance`
+          A custom warning occurred while solving type class constraints:
+
+              Data.Map's `Semigroup` instance
 
     # Specify whether to show statistics at the end of the compilation,
     # and how verbose they should be.
@@ -1447,7 +1449,9 @@ package:
       # Note: when using `byPrefix`, use the `>` for block-string:
       # see https://yaml-multiline.info/
       - byPrefix: >
-        "Data.Map"'s `Semigroup instance`
+          A custom warning occurred while solving type class constraints:
+
+              Data.Map's `Semigroup` instance
     # Convert compiler warnings for files in this package's src code
     # into errors that can fail the build.
     # Optional and defaults to false
@@ -1515,7 +1519,9 @@ package:
       # Note: when using `byPrefix`, use the `>` for block-string:
       # see https://yaml-multiline.info/
       - byPrefix: >
-        "Data.Map"'s `Semigroup instance`
+          A custom warning occurred while solving type class constraints:
+
+              Data.Map's `Semigroup` instance
     # Convert compiler warnings for files from this package's test code
     # into errors that can fail the build.
     # Optional and defaults to false


### PR DESCRIPTION
### Description of the change

Running spago 0.93.44 and purs 0.15.15, when trying out the  `byPrefix` censor example in the configuration section of the README, it doesn't actually work. 

```purescript
import Data.Array as Array
import Data.Map (Map)

--warning still happens at this declaration
fn :: Array (Map String String) -> Map String String
fn = Array.fold
```

Turns out, to properly silence this, we'd need to include the "A custom warning occurred" blurb.

### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
