### PR TITLE
[Documentation]: fix for ide and vscode links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1625,9 +1625,9 @@ packages, you should run the appropriate package-manager for that (e.g. npm).
 
 Spago dropped support for the --watch flag in `spago build` and `spago test`.
 
-VSCode users are recommended to use the [Purescript IDE](purescript-ide) extension for seamless experiences with automatic rebuilds.
+VSCode users are recommended to use the [Purescript IDE][ide-purescript] extension for seamless experiences with automatic rebuilds.
 
-Users of other editors, e.g. vim, emacs, etc., can make use of the underlying [LSP plugin](purescript-language-server).
+Users of other editors, e.g. vim, emacs, etc., can make use of the underlying [LSP plugin][purescript-language-server].
 
 If you want a very simple drop in replacement for `spago test --watch`, you can use a general purpose tool such as [watchexec]:
 
@@ -1664,6 +1664,6 @@ and similarly for the `test` folder, using that for the test sources.
 [purescript-overlay]: https://github.com/thomashoneyman/purescript-overlay
 [sample-package-set]: https://github.com/purescript/registry/blob/main/package-sets/41.2.0.json
 [watchexec]: https://github.com/watchexec/watchexec#quick-start
-[purescript-langugage-server]: https://github.com/nwolverson/purescript-language-server
+[purescript-language-server]: https://github.com/nwolverson/purescript-language-server
 [ide-purescript]: https://marketplace.visualstudio.com/items?itemName=nwolverson.ide-purescript
 [registry-dev-auth]: https://github.com/purescript/registry-dev/blob/master/SPEC.md#52-authentication


### PR DESCRIPTION

### Description of the change

Currently the Readme's links for [VScode (on line 1628)](https://github.com/purescript/spago/blob/6f6ce7ccd6d06e8ccdad58e9140993c8ea8a4ba7/README.md?plain=1#L1628) and the [LSP server (on line 1630)](https://github.com/purescript/spago/blob/6f6ce7ccd6d06e8ccdad58e9140993c8ea8a4ba7/README.md?plain=1#L1630) both are erroneous (on github they attempt to open non-existing files that result in a 404), 

These changes to `README.md` fix them via:
  1. The following `[]()` url links are changed to `[][]` reference links so they resolve to the references at the end of the document: 
      - `[Purescript IDE](purescript-ide)` -> `[Purescript IDE][purescript-ide]`
      - `[LSP plugin](purescript-language-server)` -> `[LSP plugin][purescript-language-server]`
  2. The following reference typos arecorrected: 
      - `purescript-ide` in the link `[Purescript IDE]` was changed to match the `ide-purescript` reference in the references table, as well as the url the reference points to.
      - `purescript-langugage-server` in the references table was corrected to remove the extra g to make it `purescript-language-server` to match the url, the reference in the `[LSP Plugin]` link, and proper english spelling.


### Checklist:

- [ ] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)