### PR TITLE
Fix flaky Windows CI: ignore duplicate entries in DB for package sets

### DIFF
--- a/src/Spago/Db.js
+++ b/src/Spago/Db.js
@@ -43,13 +43,13 @@ export const connectImpl = (path, logger) => {
 
 export const insertPackageSetImpl = (db, packageSet) => {
   db.prepare(
-    "INSERT INTO package_sets (version, compiler, date) VALUES (@version, @compiler, @date)"
+    "INSERT OR IGNORE INTO package_sets (version, compiler, date) VALUES (@version, @compiler, @date)"
   ).run(packageSet);
 };
 
 export const insertPackageSetEntryImpl = (db, packageSetEntry) => {
   db.prepare(
-    "INSERT INTO package_set_entries (packageSetVersion, packageName, packageVersion) VALUES (@packageSetVersion, @packageName, @packageVersion)"
+    "INSERT OR IGNORE INTO package_set_entries (packageSetVersion, packageName, packageVersion) VALUES (@packageSetVersion, @packageName, @packageVersion)"
   ).run(packageSetEntry);
 }
 


### PR DESCRIPTION
I have noticed the Windows CI failing often lately: see [here](https://github.com/purescript/spago/actions/runs/21265169442/job/61202442346) a run from Jan 22, and [here](https://github.com/purescript/spago/actions/runs/21135218426/job/60775565053) from Jan 19.

The error is:
```
  SqliteError: UNIQUE constraint failed: package_sets.version
      at insertPackageSetImpl
```

I am not sure why this only happens on windows, or why this happens in the first place - maybe SQLite locking works differently on Windows? In any case, it looks like we didn't check for insertion uniqueness, and it's a no brainer to add that, which we do here.
Again, I am puzzled: this code has been there since #1026 (Sept 2023).