### PR TITLE
Inherit stdout/stderr when using spago run, to preserve tty properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Bugfixes:
+* Preserve TTY properties for child processes in `spago run` (#1341)
+
 ## [1.0.3] - 2026-02-01
 
 Bugfixes:

--- a/src/Spago/Command/Run.purs
+++ b/src/Spago/Command/Run.purs
@@ -92,7 +92,12 @@ getNode = do
 run :: forall a. Spago (RunEnv a) Unit
 run = do
   { workspace, node, runOptions: opts, dependencies, selected, rootPath } <- ask
-  let execOptions = Cmd.defaultExecOptions { pipeStdin = Cmd.StdinPipeParent }
+  let
+    execOptions = Cmd.defaultExecOptions
+      { pipeStdin = Cmd.StdinPipeParent
+      , stdoutMode = Cmd.StdioInherit -- Preserve TTY properties for child process
+      , stderrMode = Cmd.StdioInherit -- Preserve TTY properties for child process
+      }
 
   case workspace.backend of
     Nothing -> do


### PR DESCRIPTION
Fix #1341