### PR TITLE
Set background-color on search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Bugfixes:
 * Fix flaky `SQLITE_IOERR_TRUNCATE` on Windows when multiple spago processes connect concurrently to the cache DB, by skipping `PRAGMA journal_mode = WAL` when it's already enabled (WAL mode is persistent in the DB file header) and tolerating the race on the initial set
 * Retry transient network failures (connection errors and 5xx responses) when fetching package tarballs and calling the registry API, instead of failing immediately
+* Add `backgroundColor` to search input (in `docs-search` app) so text remains legible when system's color scheme is dark
 
 ## [1.0.4] - 2026-03-30
 

--- a/docs-search/client-halogen/src/Docs/Search/App/SearchField.purs
+++ b/docs-search/client-halogen/src/Docs/Search/App/SearchField.purs
@@ -4,7 +4,7 @@ module Docs.Search.App.SearchField where
 
 import Prelude
 
-import CSS (border, borderRadius, color, em, float, floatLeft, fontWeight, lineHeight, marginBottom, marginLeft, paddingBottom, paddingLeft, paddingRight, paddingTop, pct, px, rgb, solid, weight, width)
+import CSS (backgroundColor, border, borderRadius, color, em, float, floatLeft, fontWeight, lineHeight, marginBottom, marginLeft, paddingBottom, paddingLeft, paddingRight, paddingTop, pct, px, rgb, solid, weight, white, width)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (wrap)
 import Docs.Search.URIHash as URIHash
@@ -172,6 +172,7 @@ render state =
               pursuitColor = rgb 0x1d 0x22 0x2d
               rds = px 3.0
 
+            backgroundColor white
             border solid (px 1.0) pursuitColor
             borderRadius rds rds rds rds
             color pursuitColor


### PR DESCRIPTION
Fixes #1408

### Description of the change

Explicitly setting `background-color: white` in the search `<input>`'s styles, to override UA stylesheet default of `background-color: Field` which has poor contrast with the input's `color: hsl(221.25, 21.62%, 14.51%)` in dark mode.

#### Before

<img width="1440" height="875" alt="Screenshot 2026-07-13 at 1 03 07 PM" src="https://github.com/user-attachments/assets/22961cd8-832b-4ee4-8e90-5d81e0a95c88" />


#### After

<img width="1440" height="875" alt="image" src="https://github.com/user-attachments/assets/c1996c61-af59-49bc-ab89-9c8b21cf8ad1" />


### Checklist:

- [x] Added the change to the "Unreleased" section of the changelog
- [ ] Added some example of the new feature to the `README`
- [ ] Added a test for the contribution (if applicable)

**P.S.**: the above checks are not compulsory to get a change merged, so you may skip them. However, taking care of them will result in less work for the maintainers and will be much appreciated 😊
